### PR TITLE
Add AppGallery support for publishing

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -72,6 +72,7 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
       text: 'Publishers',
       collapsed: false,
       items: [
+        { text: 'App Gallery', link: 'publishers/appgallery' },
         { text: 'App Store', link: 'publishers/appstore' },
         { text: 'fir.im', link: 'publishers/fir' },
         {

--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -97,6 +97,7 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
       text: '发布器',
       collapsed: false,
       items: [
+        { text: 'App Gallery', link: 'publishers/appgallery' },
         { text: 'App Store', link: 'publishers/appstore' },
         { text: 'fir.im', link: 'publishers/fir' },
         {

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -22,7 +22,7 @@ Fastforge is an all-in-one Flutter application packaging and distribution tool, 
 ## Key Features
 
 - 🚀 One-Click Build: Support for Android APK/AAB, iOS IPA, OpenHarmony HAP/APP and more
-- 📦 Multi-Platform Release: Support for App Store, Google Play, Firebase, Pgyer, fir.im, etc.
+- 📦 Multi-Platform Release: Support for App Store, App Gallery, Google Play, Firebase, Pgyer, fir.im, etc.
 - 🔄 CI/CD Integration: Perfect integration with GitHub Actions, GitLab CI, and more
 - 🛠 Flexible Configuration: Support for multiple environments, flavors, and custom build arguments
 

--- a/docs/en/publishers/appgallery.md
+++ b/docs/en/publishers/appgallery.md
@@ -1,0 +1,62 @@
+# App Gallery
+
+Uploads OHOS app packages to Huawei AppGallery Connect.
+
+## Set up environment variables
+
+You need to provide [AppGallery Connect API (CN)](https://developer.huawei.com/consumer/cn/doc/app/agc-help-connect-api-0000002236015554) client id and client secret in your environment.
+
+```bash
+export APP_GALLERY_CLIENT_ID="your client id"
+export APP_GALLERY_CLIENT_SECRET="your client secret"
+```
+
+## Usage
+
+Run:
+
+```bash
+fastforge publish \
+  --path dist/1.0.0+1/hello_world-1.0.0+1-ohos.app \
+  --targets appgallery \
+  --appgallery-app-id <app-id>
+```
+
+> The `--appgallery-app-id` argument passes the `app-id` to the publisher. You can also configure the same `app-id` in `distribute_options.yaml` (see example below).
+
+### Configure `distribute_options.yaml`
+
+```yaml
+variables:
+  APP_GALLERY_CLIENT_ID: 'your client id'
+  APP_GALLERY_CLIENT_SECRET: 'your client secret'
+output: dist/
+releases:
+  - name: dev
+    jobs:
+      - name: release-dev-ohos
+        package:
+          platform: ohos
+          # AppGallery expects the 'app' package format
+          target: app
+          build_args:
+            # optional, defaults to 'default' and corresponds to product name in OHOS
+            flavor: default
+        publish:
+          target: appgallery
+          args:
+            # The App ID of your application on AppGallery Connect
+            app-id: 'your app id'
+```
+
+Run:
+
+```bash
+fastforge release --name dev
+```
+
+## Related Links
+
+- [AppGallery Connect API (CN)](https://developer.huawei.com/consumer/cn/doc/app/agc-help-connect-api-0000002236015554)
+- [Create an AppGallery Connect API client (CN)](https://developer.huawei.com/consumer/cn/doc/app/agc-help-connect-api-obtain-server-auth-0000002271134661#section103mcpsimp)
+- [Upload app files with AppGallery Connect API (CN)](https://developer.huawei.com/consumer/cn/doc/app/agc-help-publish-api-guide-0000002271134665#section110mcpsimp)

--- a/docs/zh/getting-started.md
+++ b/docs/zh/getting-started.md
@@ -22,7 +22,7 @@ Fastforge 是一款全能的 Flutter 应用打包和发布工具，为您提供�
 ## 主要特性
 
 - 🚀 一键打包：支持 Android APK/AAB、iOS IPA、OpenHarmony HAP/APP 等多种格式
-- 📦 多平台发布：支持 App Store、Google Play、Firebase、蒲公英、fir.im 等
+- 📦 多平台发布：支持 App Store、App Gallery、Google Play、Firebase、蒲公英、fir.im 等
 - 🔄 CI/CD 集成：完美支持 GitHub Actions、GitLab CI 等持续集成平台
 - 🛠 灵活配置：支持多环境、多 flavor、自定义构建参数
 

--- a/docs/zh/publishers/appgallery.md
+++ b/docs/zh/publishers/appgallery.md
@@ -1,0 +1,62 @@
+# App Gallery
+
+将 OHOS App 包上传到华为 AppGallery Connect。
+
+## 设置环境变量
+
+需要在环境中提供 [AppGallery Connect API](https://developer.huawei.com/consumer/cn/doc/app/agc-help-connect-api-0000002236015554) 的 client id 和 client secret
+
+```bash
+export APP_GALLERY_CLIENT_ID="your client id"
+export APP_GALLERY_CLIENT_SECRET="your client secret"
+```
+
+## 用法
+
+运行：
+
+```bash
+fastforge publish \
+  --path dist/1.0.0+1/hello_world-1.0.0+1-ohos.app \
+  --targets appgallery \
+  --appgallery-app-id <app-id>
+```
+
+> `--appgallery-app-id` 将 `app-id` 参数传递给发布器。你也可以在 `distribute_options.yaml` 中配置相同的 `app-id`（见下例）。
+
+### 配置 `distribute_options.yaml`
+
+```yaml
+variables:
+  APP_GALLERY_CLIENT_ID: 'your client id'
+  APP_GALLERY_CLIENT_SECRET: 'your client secret'
+output: dist/
+releases:
+  - name: dev
+    jobs:
+      - name: release-dev-ohos
+        package:
+          platform: ohos
+          # 应用市场仅支持 'app' 格式
+          target: app
+          build_args:
+            # 可选，默认为 default, 对应 ohos 中的 product name
+            flavor: default
+        publish:
+          target: appgallery
+          args:
+            # 应用在 AppGallery Connect 上的 APP ID
+            app-id: 'your app id'
+```
+
+运行：
+
+```bash
+fastforge release --name dev
+```
+
+## 相关链接
+
+- [AppGallery Connect API](https://developer.huawei.com/consumer/cn/doc/app/agc-help-connect-api-0000002236015554)
+- [创建 AppGallery Connect API 客户端](https://developer.huawei.com/consumer/cn/doc/app/agc-help-connect-api-obtain-server-auth-0000002271134661#section103mcpsimp)
+- [通过 AppGallery Connect API 上传应用文件](https://developer.huawei.com/consumer/cn/doc/app/agc-help-publish-api-guide-0000002271134665#section110mcpsimp)

--- a/packages/flutter_app_publisher/lib/src/flutter_app_publisher.dart
+++ b/packages/flutter_app_publisher/lib/src/flutter_app_publisher.dart
@@ -6,6 +6,7 @@ import 'package:flutter_app_publisher/src/publishers/publishers.dart';
 class FlutterAppPublisher {
   final List<AppPackagePublisher> _publishers = [
     AppPackagePublisherAppCenter(),
+    AppPackagePublisherAppGallery(),
     AppPackagePublisherAppStore(),
     AppPackagePublisherFir(),
     AppPackagePublisherFirebase(),

--- a/packages/flutter_app_publisher/lib/src/publishers/appgallery/app_package_publisher_appgallery.dart
+++ b/packages/flutter_app_publisher/lib/src/publishers/appgallery/app_package_publisher_appgallery.dart
@@ -1,0 +1,195 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_app_publisher/flutter_app_publisher.dart';
+import 'package:flutter_app_publisher/src/publishers/appgallery/publish_appgallery_config.dart';
+
+/// Huawei AppGallery Connect publishing API doc
+/// [https://developer.huawei.com/consumer/cn/doc/app/agc-help-test-api-add-test-package-0000002236201330]
+class AppPackagePublisherAppGallery extends AppPackagePublisher {
+  final Dio _dio = Dio();
+
+  @override
+  String get name => 'appgallery';
+
+  @override
+  List<String> get supportedPlatforms => ['ohos'];
+
+  @override
+  Future<PublishResult> publish(
+    FileSystemEntity fileSystemEntity, {
+    Map<String, String>? environment,
+    Map<String, dynamic>? publishArguments,
+    PublishProgressCallback? onPublishProgress,
+  }) async {
+    File file = fileSystemEntity as File;
+    PublishAppGalleryConfig publishConfig = PublishAppGalleryConfig.parse(
+      environment,
+      publishArguments,
+    );
+
+    try {
+      String fileName = file.uri.pathSegments.last;
+
+      // Get access token (1/4)
+      String accessToken = await getAccessToken(
+        publishConfig.clientId,
+        publishConfig.clientSecret,
+      );
+
+      // Get upload URL (2/4)
+      Map<String, dynamic> uploadUrlInfo = await getUploadUrl(
+        publishConfig.clientId,
+        accessToken,
+        publishConfig.appId,
+        fileName,
+        file.lengthSync(),
+      );
+
+      // Upload file (3/4)
+      await uploadFile(
+        uploadUrlInfo,
+        file,
+        onPublishProgress,
+      );
+
+      // Apply Package Info (4/4)
+      await applyUpload(
+        publishConfig.clientId,
+        accessToken,
+        publishConfig.appId,
+        fileName,
+        uploadUrlInfo['objectId'],
+      );
+
+      return PublishResult(
+        url:
+            'https://developer.huawei.com/consumer/cn/service/josp/agc/index.html',
+      );
+    } catch (e) {
+      throw PublishError(e.toString());
+    }
+  }
+
+  Future<String> getAccessToken(
+    String clientId,
+    String clientSecret,
+  ) async {
+    Map<String, dynamic> data = {
+      'grant_type': 'client_credentials',
+      'client_id': clientId,
+      'client_secret': clientSecret,
+    };
+    try {
+      Response response = await _dio.post(
+        'https://connect-api.cloud.huawei.com/api/oauth2/v1/token',
+        data: data,
+      );
+      if (response.statusCode == 200 && response.data['access_token'] != null) {
+        return response.data['access_token'];
+      } else {
+        throw PublishError('getAccessToken error: ${response.data}');
+      }
+    } catch (e) {
+      throw PublishError(e.toString());
+    }
+  }
+
+  Future<Map<String, dynamic>> getUploadUrl(
+    String clientId,
+    String accessToken,
+    String appId,
+    String fileName,
+    int contentLength,
+  ) async {
+    Map<String, dynamic> query = {
+      'appId': appId,
+      'fileName': fileName,
+      'contentLength': contentLength,
+    };
+    try {
+      Response response = await _dio.get(
+        'https://connect-api.cloud.huawei.com/api/publish/v2/upload-url/for-obs',
+        queryParameters: query,
+        options: Options(
+          headers: {
+            'client_id': clientId,
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          },
+        ),
+      );
+      if (response.data?['ret']?['code'] == 0) {
+        return Map<String, dynamic>.from(response.data['urlInfo']);
+      } else {
+        throw PublishError('getUploadUrl error: ${response.data}');
+      }
+    } catch (e) {
+      throw PublishError(e.toString());
+    }
+  }
+
+  Future<void> uploadFile(
+    Map<String, dynamic> urlInfo,
+    File file,
+    PublishProgressCallback? onPublishProgress,
+  ) async {
+    try {
+      Response response = await _dio.put(
+        urlInfo['url'] as String,
+        data: file.openRead(),
+        options: Options(
+          headers: {
+            ...Map<String, String>.from(urlInfo['headers']),
+            'Content-Length': file.lengthSync().toString(),
+          },
+        ),
+        onSendProgress: (count, total) {
+          onPublishProgress?.call(count, total);
+        },
+      );
+      if (response.statusCode != 200) {
+        throw PublishError('uploadFile error: ${response.data}');
+      }
+    } catch (e) {
+      throw PublishError('uploadFile error: ${e.toString()}');
+    }
+  }
+
+  Future<Map<String, dynamic>> applyUpload(
+    String clientId,
+    String accessToken,
+    String appId,
+    String fileName,
+    String objectId,
+  ) async {
+    Map<String, dynamic> headers = {
+      'client_id': clientId,
+      'Authorization': 'Bearer $accessToken',
+    };
+    Map<String, dynamic> query = {
+      'appId': appId,
+      'releaseType': 1,
+      'releasePhase': 0,
+    };
+    Map<String, dynamic> data = {
+      'fileName': fileName,
+      'objectId': objectId,
+    };
+    try {
+      Response response = await _dio.put(
+        'https://connect-api.cloud.huawei.com/api/publish/v3/app-package-info',
+        queryParameters: query,
+        data: data,
+        options: Options(headers: headers),
+      );
+      if (response.statusCode == 200 && response.data['ret']['code'] == 0) {
+        return Map<String, dynamic>.from(response.data);
+      } else {
+        throw PublishError('applyUpload error: ${response.data}');
+      }
+    } catch (e) {
+      throw PublishError('applyUpload error: ${e.toString()}');
+    }
+  }
+}

--- a/packages/flutter_app_publisher/lib/src/publishers/appgallery/publish_appgallery_config.dart
+++ b/packages/flutter_app_publisher/lib/src/publishers/appgallery/publish_appgallery_config.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+
+import 'package:flutter_app_publisher/flutter_app_publisher.dart';
+
+const kEnvAppGalleryClientId = 'APP_GALLERY_CLIENT_ID';
+const kEnvAppGalleryClientSecret = 'APP_GALLERY_CLIENT_SECRET';
+
+class PublishAppGalleryConfig extends PublishConfig {
+  PublishAppGalleryConfig({
+    required this.clientId,
+    required this.clientSecret,
+    required this.appId,
+  });
+
+  factory PublishAppGalleryConfig.parse(
+    Map<String, String>? environment,
+    Map<String, dynamic>? publishArguments,
+  ) {
+    String? clientId =
+        (environment ?? Platform.environment)[kEnvAppGalleryClientId];
+    if ((clientId ?? '').isEmpty) {
+      throw PublishError(
+        'Missing `$kEnvAppGalleryClientId` environment variable.',
+      );
+    }
+
+    String? clientSecret =
+        (environment ?? Platform.environment)[kEnvAppGalleryClientSecret];
+    if ((clientSecret ?? '').isEmpty) {
+      throw PublishError(
+        'Missing `$kEnvAppGalleryClientSecret` environment variable.',
+      );
+    }
+
+    String? appId = publishArguments?['app-id'];
+    if ((appId ?? '').isEmpty) {
+      throw PublishError('Missing `app-id` arg');
+    }
+
+    return PublishAppGalleryConfig(
+      clientId: clientId!,
+      clientSecret: clientSecret!,
+      appId: appId!,
+    );
+  }
+
+  final String clientId;
+  final String clientSecret;
+  final String appId;
+}

--- a/packages/flutter_app_publisher/lib/src/publishers/publishers.dart
+++ b/packages/flutter_app_publisher/lib/src/publishers/publishers.dart
@@ -1,4 +1,5 @@
 export 'appcenter/app_package_publisher_appcenter.dart';
+export 'appgallery/app_package_publisher_appgallery.dart';
 export 'appstore/app_package_publisher_appstore.dart';
 export 'fir/app_package_publisher_fir.dart';
 export 'firebase/app_package_publisher_firebase.dart';

--- a/packages/unified_distributor/lib/src/cli/command_publish.dart
+++ b/packages/unified_distributor/lib/src/cli/command_publish.dart
@@ -21,6 +21,7 @@ class CommandPublish extends Command {
       'targets',
       aliases: ['target'],
       valueHelp: [
+        'appgallery',
         'appstore',
         'fir',
         'firebase',
@@ -40,6 +41,14 @@ class CommandPublish extends Command {
         'The version of the app',
         'Must follow semantic versioning format, e.g., 1.0.0, 2.1.3-beta.1',
       ].join('\n'),
+    );
+
+    // AppGallery
+    argParser.addSeparator('appgallery');
+    argParser.addOption(
+      'appgallery-app-id',
+      valueHelp: '',
+      help: 'The unique ID of the application on AppGallery.',
     );
 
     // Firebase
@@ -214,6 +223,7 @@ class CommandPublish extends Command {
 
     Map<String, String?> publishArguments = {
       'app-version': argResults?['app-version'],
+      'appgallery-app-id': argResults?['appgallery-app-id'],
       'firebase-app': argResults?['firebase-app'],
       'firebase-release-notes': argResults?['firebase-release-notes'],
       'firebase-release-notes-file': argResults?['firebase-release-notes-file'],


### PR DESCRIPTION
Introduce support for publishing to Huawei AppGallery, including the addition of an app ID option in the publish command and updates to the documentation.