### PR TITLE
Feat/pgyer upload params

### DIFF
--- a/docs/en/distribute-options.md
+++ b/docs/en/distribute-options.md
@@ -31,6 +31,29 @@ releases:
             dart-define:
               APP_ENV: dev
         publish_to: pgyer
+      # Build apk and specify parameters (optional) to publish to pgyer
+      # Params reference: https://www.pgyer.com/doc/view/api#fastUploadApp
+      - name: release-staging-android
+        package:
+          platform: android
+          target: apk
+          build_args:
+            flavor: dev
+            target-platform: android-arm,android-arm64
+            dart-define:
+              APP_ENV: dev
+        publish:
+          target: pgyer
+          args:
+            pgyer-oversea: 1
+            pgyer-install-type: 2
+            pgyer-password: 123456
+            pgyer-description: Your app description
+            pgyer-update-description: Update description
+            pgyer-install-date: 1
+            pgyer-install-start-date: 2025-09-30
+            pgyer-install-end-date: 2025-10-30
+            pgyer-channel-shortcut: XXXXXX
 ```
 
 ## Specification

--- a/docs/en/publishers/pgyer.md
+++ b/docs/en/publishers/pgyer.md
@@ -24,18 +24,6 @@ fastforge publish \
 
 You can provide additional parameters to customize your upload:
 
-```
-fastforge publish \
-  --path dist/1.0.0+1/hello_world-1.0.0+1-android.apk \
-  --targets pgyer \
-  --pgyer-description "My awesome app description" \
-  --pgyer-update-description "Fixed bugs and improved performance" \
-  --pgyer-install-type 2 \
-  --pgyer-password "mypassword"
-```
-
-### Available Parameters
-
 - `--pgyer-oversea`: Upload acceleration (1=overseas, 2=domestic, empty=auto-detect)
 - `--pgyer-install-type`: Installation type (1=public, 2=password, 3=invite, default: 1)
 - `--pgyer-password`: App installation password (required for password installation)

--- a/docs/en/publishers/pgyer.md
+++ b/docs/en/publishers/pgyer.md
@@ -19,3 +19,29 @@ fastforge publish \
   --path dist/1.0.0+1/hello_world-1.0.0+1-android.apk \
   --targets pgyer
 ```
+
+## Optional Parameters
+
+You can provide additional parameters to customize your upload:
+
+```
+fastforge publish \
+  --path dist/1.0.0+1/hello_world-1.0.0+1-android.apk \
+  --targets pgyer \
+  --pgyer-description "My awesome app description" \
+  --pgyer-update-description "Fixed bugs and improved performance" \
+  --pgyer-install-type 2 \
+  --pgyer-password "mypassword"
+```
+
+### Available Parameters
+
+- `--pgyer-oversea`: Upload acceleration (1=overseas, 2=domestic, empty=auto-detect)
+- `--pgyer-install-type`: Installation type (1=public, 2=password, 3=invite, default: 1)
+- `--pgyer-password`: App installation password (required for password installation)
+- `--pgyer-description`: Application description (optional)
+- `--pgyer-update-description`: Version update description (optional)
+- `--pgyer-install-date`: Installation validity (1=set time, 2=permanent, optional)
+- `--pgyer-install-start-date`: Installation validity start date (e.g., 2018-01-01)
+- `--pgyer-install-end-date`: Installation validity end date (e.g., 2018-12-31)
+- `--pgyer-channel-shortcut`: Channel shortcut for update (e.g., abcd)

--- a/docs/zh/distribute-options.md
+++ b/docs/zh/distribute-options.md
@@ -31,6 +31,29 @@ releases:
             dart-define:
               APP_ENV: dev
         publish_to: pgyer
+      # 构建 apk 包并指定参数(可选)发布到 pyger
+      # 参数说明: https://www.pgyer.com/doc/view/api#fastUploadApp
+      - name: release-staging-android
+        package:
+          platform: android
+          target: apk
+          build_args:
+            flavor: dev
+            target-platform: android-arm,android-arm64
+            dart-define:
+              APP_ENV: dev
+        publish:
+          target: pgyer
+          args:
+            pgyer-oversea: 1
+            pgyer-install-type: 2
+            pgyer-password: 123456
+            pgyer-description: 你的应用说明
+            pgyer-update-description: 更新说明
+            pgyer-install-date: 1
+            pgyer-install-start-date: 2025-09-30
+            pgyer-install-end-date: 2025-10-30
+            pgyer-channel-shortcut: XXXXXX
 ```
 
 ## Specification

--- a/docs/zh/publishers/pgyer.md
+++ b/docs/zh/publishers/pgyer.md
@@ -24,18 +24,6 @@ fastforge publish \
 
 你可以提供额外的参数来自定义上传：
 
-```
-fastforge publish \
-  --path dist/1.0.0+1/hello_world-1.0.0+1-android.apk \
-  --targets pgyer \
-  --pgyer-description "我的应用描述" \
-  --pgyer-update-description "修复了bug并提升了性能" \
-  --pgyer-install-type 2 \
-  --pgyer-password "mypassword"
-```
-
-### 可用参数
-
 - `--pgyer-oversea`: 上传加速选择（1=海外加速，2=国内加速，空=自动判断）
 - `--pgyer-install-type`: 应用安装方式（1=公开安装，2=密码安装，3=邀请安装，默认：1）
 - `--pgyer-password`: 应用安装密码（密码安装时必需）

--- a/docs/zh/publishers/pgyer.md
+++ b/docs/zh/publishers/pgyer.md
@@ -19,3 +19,29 @@ fastforge publish \
   --path dist/1.0.0+1/hello_world-1.0.0+1-android.apk \
   --targets pgyer
 ```
+
+## 可选参数
+
+你可以提供额外的参数来自定义上传：
+
+```
+fastforge publish \
+  --path dist/1.0.0+1/hello_world-1.0.0+1-android.apk \
+  --targets pgyer \
+  --pgyer-description "我的应用描述" \
+  --pgyer-update-description "修复了bug并提升了性能" \
+  --pgyer-install-type 2 \
+  --pgyer-password "mypassword"
+```
+
+### 可用参数
+
+- `--pgyer-oversea`: 上传加速选择（1=海外加速，2=国内加速，空=自动判断）
+- `--pgyer-install-type`: 应用安装方式（1=公开安装，2=密码安装，3=邀请安装，默认：1）
+- `--pgyer-password`: 应用安装密码（密码安装时必需）
+- `--pgyer-description`: 应用介绍（可选）
+- `--pgyer-update-description`: 版本更新描述（可选）
+- `--pgyer-install-date`: 是否设置安装有效期（1=设置有效时间，2=长期有效，可选）
+- `--pgyer-install-start-date`: 安装有效期开始时间（如：2018-01-01）
+- `--pgyer-install-end-date`: 安装有效期结束时间（如：2018-12-31）
+- `--pgyer-channel-shortcut`: 所需更新指定的渠道短链接（如：abcd）

--- a/packages/flutter_app_publisher/lib/src/publishers/pgyer/app_package_publisher_pgyer.dart
+++ b/packages/flutter_app_publisher/lib/src/publishers/pgyer/app_package_publisher_pgyer.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_app_publisher/src/api/app_package_publisher.dart';
@@ -27,6 +28,8 @@ class AppPackagePublisherPgyer extends AppPackagePublisher {
 
     // 使用配置类解析参数
     final config = PublishPgyerConfig.parse(environment, publishArguments);
+    print(
+        'config:\n${const JsonEncoder.withIndent('  ').convert(config.toJson())}');
 
     var tokenInfo = await getCOSToken(config, file.path);
     String uploadKey = await uploadApp(tokenInfo, file, onPublishProgress);

--- a/packages/flutter_app_publisher/lib/src/publishers/pgyer/app_package_publisher_pgyer.dart
+++ b/packages/flutter_app_publisher/lib/src/publishers/pgyer/app_package_publisher_pgyer.dart
@@ -2,8 +2,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_app_publisher/src/api/app_package_publisher.dart';
-
-const kEnvPgyerApiKey = 'PGYER_API_KEY';
+import 'package:flutter_app_publisher/src/publishers/pgyer/publish_pgyer_config.dart';
 
 /// pgyer doc [https://www.pgyer.com/doc/view/api#fastUploadApp]
 class AppPackagePublisherPgyer extends AppPackagePublisher {
@@ -25,19 +24,18 @@ class AppPackagePublisherPgyer extends AppPackagePublisher {
     PublishProgressCallback? onPublishProgress,
   }) async {
     File file = fileSystemEntity as File;
-    String? apiKey = (environment ?? Platform.environment)[kEnvPgyerApiKey];
-    if ((apiKey ?? '').isEmpty) {
-      throw PublishError('Missing `$kEnvPgyerApiKey` environment variable.');
-    }
 
-    var tokenInfo = await getCOSToken(apiKey!, file.path);
+    // 使用配置类解析参数
+    final config = PublishPgyerConfig.parse(environment, publishArguments);
+
+    var tokenInfo = await getCOSToken(config, file.path);
     String uploadKey = await uploadApp(tokenInfo, file, onPublishProgress);
     if (uploadKey.isEmpty) {
       throw PublishError('UploadApp error');
     }
     // 重试次数设置为 0
     tryCount = 0;
-    var buildResult = await getBuildInfo(apiKey, uploadKey);
+    var buildResult = await getBuildInfo(config.apiKey, uploadKey);
     String buildKey = buildResult.data!['data']['buildKey'];
     return PublishResult(
       url: 'http://www.pgyer.com/$buildKey',
@@ -45,13 +43,40 @@ class AppPackagePublisherPgyer extends AppPackagePublisher {
   }
 
   /// 获取上传 Token 信息
-  /// [apiKey] apiKey
-  /// [filePath] 文件路径
-  Future<Response> getCOSToken(String apiKey, String filePath) async {
-    FormData formData = FormData.fromMap({
-      '_api_key': apiKey,
+  ///
+  /// 构建包含所有 pgyer API 参数的请求数据
+  /// 参考文档: https://www.pgyer.com/doc/view/api#fastUploadApp
+  ///
+  /// [config] 配置信息，包含所有 pgyer API 参数
+  /// [filePath] 文件路径，用于确定 buildType
+  Future<Response> getCOSToken(
+    PublishPgyerConfig config,
+    String filePath,
+  ) async {
+    Map<String, dynamic> formDataMap = {
+      '_api_key': config.apiKey,
       'buildType': filePath.split('.').last,
-    });
+    };
+
+    // 添加所有可选参数，只在有值时才添加
+    _addOptionalParameter(formDataMap, 'oversea', config.oversea);
+    _addOptionalParameter(
+        formDataMap, 'buildInstallType', config.buildInstallType);
+    _addOptionalParameter(formDataMap, 'buildPassword', config.buildPassword);
+    _addOptionalParameter(
+        formDataMap, 'buildDescription', config.buildDescription);
+    _addOptionalParameter(
+        formDataMap, 'buildUpdateDescription', config.buildUpdateDescription);
+    _addOptionalParameter(
+        formDataMap, 'buildInstallDate', config.buildInstallDate);
+    _addOptionalParameter(
+        formDataMap, 'buildInstallStartDate', config.buildInstallStartDate);
+    _addOptionalParameter(
+        formDataMap, 'buildInstallEndDate', config.buildInstallEndDate);
+    _addOptionalParameter(
+        formDataMap, 'buildChannelShortcut', config.buildChannelShortcut);
+
+    FormData formData = FormData.fromMap(formDataMap);
     try {
       Response response = await _dio.post(
         'https://www.pgyer.com/apiv2/app/getCOSToken',
@@ -63,6 +88,24 @@ class AppPackagePublisherPgyer extends AppPackagePublisher {
       return response;
     } catch (e) {
       throw PublishError(e.toString());
+    }
+  }
+
+  /// 添加可选参数到表单数据中
+  ///
+  /// 只在参数不为空且不为空字符串时才添加
+  ///
+  /// [formDataMap] 表单数据映射
+  /// [key] 参数键名
+  /// [value] 参数值
+  void _addOptionalParameter(
+      Map<String, dynamic> formDataMap, String key, dynamic value) {
+    if (value != null) {
+      if (value is String && value.isNotEmpty) {
+        formDataMap[key] = value;
+      } else if (value is! String) {
+        formDataMap[key] = value;
+      }
     }
   }
 

--- a/packages/flutter_app_publisher/lib/src/publishers/pgyer/publish_pgyer_config.dart
+++ b/packages/flutter_app_publisher/lib/src/publishers/pgyer/publish_pgyer_config.dart
@@ -1,9 +1,109 @@
+import 'dart:io';
+
 import 'package:flutter_app_publisher/src/api/app_package_publisher.dart';
 
+const kEnvPgyerApiKey = 'PGYER_API_KEY';
+
+/// Pgyer 发布配置类
+///
+/// 支持 pgyer.com API 的所有可选参数
+/// 文档参考: https://www.pgyer.com/doc/view/api#fastUploadApp
 class PublishPgyerConfig extends PublishConfig {
   PublishPgyerConfig({
     required this.apiKey,
+    this.oversea,
+    this.buildInstallType,
+    this.buildPassword,
+    this.buildDescription,
+    this.buildUpdateDescription,
+    this.buildInstallDate,
+    this.buildInstallStartDate,
+    this.buildInstallEndDate,
+    this.buildChannelShortcut,
   });
 
+  /// 从环境变量和发布参数中解析配置
+  factory PublishPgyerConfig.parse(
+    Map<String, String>? environment,
+    Map<String, dynamic>? publishArguments,
+  ) {
+    String? apiKey = (environment ?? Platform.environment)[kEnvPgyerApiKey];
+    if ((apiKey ?? '').isEmpty) {
+      throw PublishError('Missing `$kEnvPgyerApiKey` environment variable.');
+    }
+
+    return PublishPgyerConfig(
+      apiKey: apiKey!,
+      oversea: _parseInt(publishArguments?['oversea']),
+      buildInstallType: _parseInt(publishArguments?['install-type']),
+      buildPassword: publishArguments?['password'],
+      buildDescription: publishArguments?['description'],
+      buildUpdateDescription: publishArguments?['update-description'],
+      buildInstallDate: _parseInt(publishArguments?['install-date']),
+      buildInstallStartDate: publishArguments?['install-start-date'],
+      buildInstallEndDate: publishArguments?['install-end-date'],
+      buildChannelShortcut: publishArguments?['channel-shortcut'],
+    );
+  }
+
+  /// Pgyer API Key (必需)
   final String apiKey;
+
+  /// 是否使用海外加速上传
+  /// 1: 使用海外加速上传
+  /// 2: 国内加速上传
+  /// null: 根据 IP 自动判断
+  final int? oversea;
+
+  /// 应用安装方式
+  /// 1: 公开安装 (默认)
+  /// 2: 密码安装
+  /// 3: 邀请安装
+  final int? buildInstallType;
+
+  /// 设置App安装密码
+  /// 密码为空时默认公开安装
+  final String? buildPassword;
+
+  /// 应用介绍
+  /// 如没有介绍请传空字符串，或不传
+  final String? buildDescription;
+
+  /// 版本更新描述
+  /// 请传空字符串，或不传
+  final String? buildUpdateDescription;
+
+  /// 是否设置安装有效期
+  /// 1: 设置有效时间
+  /// 2: 长期有效
+  /// 如果不填写不修改上一次的设置
+  final int? buildInstallDate;
+
+  /// 安装有效期开始时间
+  /// 字符串型，如：2018-01-01
+  final String? buildInstallStartDate;
+
+  /// 安装有效期结束时间
+  /// 字符串型，如：2018-12-31
+  final String? buildInstallEndDate;
+
+  /// 所需更新指定的渠道短链接
+  /// 渠道短链接须为已创建成功的，并且只可指定一个渠道
+  /// 字符串型，如：abcd
+  final String? buildChannelShortcut;
+
+  /// 解析整数值
+  ///
+  /// 支持字符串和数字类型的转换
+  ///
+  /// [value] 要解析的值
+  /// 返回解析后的整数值，如果解析失败则返回 null
+  static int? _parseInt(dynamic value) {
+    if (value == null) return null;
+    if (value is int) return value;
+    if (value is String) {
+      return int.tryParse(value);
+    }
+    return null;
+  }
 }

--- a/packages/flutter_app_publisher/lib/src/publishers/pgyer/publish_pgyer_config.dart
+++ b/packages/flutter_app_publisher/lib/src/publishers/pgyer/publish_pgyer_config.dart
@@ -36,13 +36,15 @@ class PublishPgyerConfig extends PublishConfig {
       apiKey: apiKey!,
       oversea: _parseInt(publishArguments?['oversea']),
       buildInstallType: _parseInt(publishArguments?['install-type']),
-      buildPassword: publishArguments?['password'],
-      buildDescription: publishArguments?['description'],
-      buildUpdateDescription: publishArguments?['update-description'],
+      buildPassword: _parseString(publishArguments?['password']),
+      buildDescription: _parseString(publishArguments?['description']),
+      buildUpdateDescription:
+          _parseString(publishArguments?['update-description']),
       buildInstallDate: _parseInt(publishArguments?['install-date']),
-      buildInstallStartDate: publishArguments?['install-start-date'],
-      buildInstallEndDate: publishArguments?['install-end-date'],
-      buildChannelShortcut: publishArguments?['channel-shortcut'],
+      buildInstallStartDate:
+          _parseString(publishArguments?['install-start-date']),
+      buildInstallEndDate: _parseString(publishArguments?['install-end-date']),
+      buildChannelShortcut: _parseString(publishArguments?['channel-shortcut']),
     );
   }
 
@@ -105,5 +107,28 @@ class PublishPgyerConfig extends PublishConfig {
       return int.tryParse(value);
     }
     return null;
+  }
+
+  /// 解析字符串值
+  ///
+  /// 支持将任意类型安全转换为字符串；空字符串将按原样保留
+  static String? _parseString(dynamic value) {
+    if (value == null) return null;
+    if (value is String) return value;
+    return value.toString();
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'oversea': oversea,
+      'buildInstallType': buildInstallType,
+      'buildPassword': buildPassword,
+      'buildDescription': buildDescription,
+      'buildUpdateDescription': buildUpdateDescription,
+      'buildInstallDate': buildInstallDate,
+      'buildInstallStartDate': buildInstallStartDate,
+      'buildInstallEndDate': buildInstallEndDate,
+      'buildChannelShortcut': buildChannelShortcut,
+    }..removeWhere((key, value) => value == null);
   }
 }

--- a/packages/flutter_app_publisher/test/src/publishers/pgyer/publish_pgyer_config_test.dart
+++ b/packages/flutter_app_publisher/test/src/publishers/pgyer/publish_pgyer_config_test.dart
@@ -1,0 +1,218 @@
+import 'package:flutter_app_publisher/src/api/app_package_publisher.dart';
+import 'package:flutter_app_publisher/src/publishers/pgyer/publish_pgyer_config.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PublishPgyerConfig', () {
+    group('constructor', () {
+      test('creates instance with all parameters', () {
+        final config = PublishPgyerConfig(
+          apiKey: 'test_api_key',
+          oversea: 1,
+          buildInstallType: 2,
+          buildPassword: 'test_password',
+          buildDescription: 'Test app description',
+          buildUpdateDescription: 'Test update description',
+          buildInstallDate: 1,
+          buildInstallStartDate: '2024-01-01',
+          buildInstallEndDate: '2024-12-31',
+          buildChannelShortcut: 'test_channel',
+        );
+
+        expect(config.apiKey, equals('test_api_key'));
+        expect(config.oversea, equals(1));
+        expect(config.buildInstallType, equals(2));
+        expect(config.buildPassword, equals('test_password'));
+        expect(config.buildDescription, equals('Test app description'));
+        expect(
+            config.buildUpdateDescription, equals('Test update description'));
+        expect(config.buildInstallDate, equals(1));
+        expect(config.buildInstallStartDate, equals('2024-01-01'));
+        expect(config.buildInstallEndDate, equals('2024-12-31'));
+        expect(config.buildChannelShortcut, equals('test_channel'));
+      });
+
+      test('creates instance with only required parameters', () {
+        final config = PublishPgyerConfig(
+          apiKey: 'test_api_key',
+        );
+
+        expect(config.apiKey, equals('test_api_key'));
+        expect(config.oversea, isNull);
+        expect(config.buildInstallType, isNull);
+        expect(config.buildPassword, isNull);
+        expect(config.buildDescription, isNull);
+        expect(config.buildUpdateDescription, isNull);
+        expect(config.buildInstallDate, isNull);
+        expect(config.buildInstallStartDate, isNull);
+        expect(config.buildInstallEndDate, isNull);
+        expect(config.buildChannelShortcut, isNull);
+      });
+    });
+
+    group('parse', () {
+      test('parses with valid environment and all arguments', () {
+        final environment = {'PGYER_API_KEY': 'test_api_key'};
+        final publishArguments = {
+          'oversea': 1,
+          'install-type': 2,
+          'password': 'test_password',
+          'description': 'Test app description',
+          'update-description': 'Test update description',
+          'install-date': 1,
+          'install-start-date': '2024-01-01',
+          'install-end-date': '2024-12-31',
+          'channel-shortcut': 'test_channel',
+        };
+
+        print('🔧 Environment: $environment');
+        print('📝 Publish Arguments: $publishArguments');
+
+        final config = PublishPgyerConfig.parse(environment, publishArguments);
+
+        print('✅ Parsed Config:');
+        print('   API Key: ${config.apiKey}');
+        print('   Oversea: ${config.oversea}');
+        print('   Install Type: ${config.buildInstallType}');
+        print('   Password: ${config.buildPassword}');
+        print('   Description: ${config.buildDescription}');
+        print('   Update Description: ${config.buildUpdateDescription}');
+        print('   Install Date: ${config.buildInstallDate}');
+        print('   Install Start Date: ${config.buildInstallStartDate}');
+        print('   Install End Date: ${config.buildInstallEndDate}');
+        print('   Channel Shortcut: ${config.buildChannelShortcut}');
+
+        expect(config.apiKey, equals('test_api_key'));
+        expect(config.oversea, equals(1));
+        expect(config.buildInstallType, equals(2));
+        expect(config.buildPassword, equals('test_password'));
+        expect(config.buildDescription, equals('Test app description'));
+        expect(
+            config.buildUpdateDescription, equals('Test update description'));
+        expect(config.buildInstallDate, equals(1));
+        expect(config.buildInstallStartDate, equals('2024-01-01'));
+        expect(config.buildInstallEndDate, equals('2024-12-31'));
+        expect(config.buildChannelShortcut, equals('test_channel'));
+      });
+
+      test('parses with only required parameters', () {
+        final environment = {'PGYER_API_KEY': 'test_api_key'};
+        final publishArguments = <String, dynamic>{};
+
+        final config = PublishPgyerConfig.parse(environment, publishArguments);
+
+        expect(config.apiKey, equals('test_api_key'));
+        expect(config.oversea, isNull);
+        expect(config.buildInstallType, isNull);
+        expect(config.buildPassword, isNull);
+        expect(config.buildDescription, isNull);
+        expect(config.buildUpdateDescription, isNull);
+        expect(config.buildInstallDate, isNull);
+        expect(config.buildInstallStartDate, isNull);
+        expect(config.buildInstallEndDate, isNull);
+        expect(config.buildChannelShortcut, isNull);
+      });
+
+      test('parses with partial arguments', () {
+        final environment = {'PGYER_API_KEY': 'test_api_key'};
+        final publishArguments = {
+          'description': 'Test app description',
+          'install-type': 2,
+          'password': 'test_password',
+        };
+
+        final config = PublishPgyerConfig.parse(environment, publishArguments);
+
+        expect(config.apiKey, equals('test_api_key'));
+        expect(config.buildDescription, equals('Test app description'));
+        expect(config.buildInstallType, equals(2));
+        expect(config.buildPassword, equals('test_password'));
+        expect(config.oversea, isNull);
+        expect(config.buildUpdateDescription, isNull);
+        expect(config.buildInstallDate, isNull);
+        expect(config.buildInstallStartDate, isNull);
+        expect(config.buildInstallEndDate, isNull);
+        expect(config.buildChannelShortcut, isNull);
+      });
+
+      test('handles string values for numeric parameters', () {
+        final environment = {'PGYER_API_KEY': 'test_api_key'};
+        final publishArguments = {
+          'oversea': '1',
+          'install-type': '2',
+          'install-date': '1',
+        };
+
+        print('🔄 String to Int Conversion Test:');
+        print('   Input Arguments: $publishArguments');
+        print('   Expected: oversea=1, install-type=2, install-date=1');
+
+        final config = PublishPgyerConfig.parse(environment, publishArguments);
+
+        print(
+            '   Result: oversea=${config.oversea}, install-type=${config.buildInstallType}, install-date=${config.buildInstallDate}');
+
+        expect(config.oversea, equals(1));
+        expect(config.buildInstallType, equals(2));
+        expect(config.buildInstallDate, equals(1));
+      });
+
+      test('throws PublishError when PGYER_API_KEY is missing', () {
+        final environment = <String, String>{};
+        final publishArguments = <String, dynamic>{};
+
+        print('❌ Error Test - Missing API Key:');
+        print('   Environment: $environment');
+        print('   Expected: PublishError with missing API key message');
+
+        expect(
+          () => PublishPgyerConfig.parse(environment, publishArguments),
+          throwsA(
+            isA<PublishError>().having(
+              (e) => e.message,
+              'message',
+              contains('Missing `PGYER_API_KEY` environment variable'),
+            ),
+          ),
+        );
+      });
+
+      test('throws PublishError when PGYER_API_KEY is empty', () {
+        final environment = {'PGYER_API_KEY': ''};
+        final publishArguments = <String, dynamic>{};
+
+        expect(
+          () => PublishPgyerConfig.parse(environment, publishArguments),
+          throwsA(
+            isA<PublishError>().having(
+              (e) => e.message,
+              'message',
+              contains('Missing `PGYER_API_KEY` environment variable'),
+            ),
+          ),
+        );
+      });
+
+      test('handles null publishArguments', () {
+        final environment = {'PGYER_API_KEY': 'test_api_key'};
+
+        final config = PublishPgyerConfig.parse(environment, null);
+
+        expect(config.apiKey, equals('test_api_key'));
+        expect(config.oversea, isNull);
+        expect(config.buildInstallType, isNull);
+        expect(config.buildPassword, isNull);
+        expect(config.buildDescription, isNull);
+        expect(config.buildUpdateDescription, isNull);
+        expect(config.buildInstallDate, isNull);
+        expect(config.buildInstallStartDate, isNull);
+        expect(config.buildInstallEndDate, isNull);
+        expect(config.buildChannelShortcut, isNull);
+      });
+
+      // Note: Testing null environment is difficult because it falls back to
+      // Platform.environment, which depends on actual system environment variables.
+      // This test is skipped to avoid flaky behavior.
+    });
+  });
+}

--- a/packages/unified_distributor/lib/src/cli/command_publish.dart
+++ b/packages/unified_distributor/lib/src/cli/command_publish.dart
@@ -164,6 +164,54 @@ class CommandPublish extends Command {
     argParser.addOption('minio-bucket', valueHelp: '');
     argParser.addOption('minio-savekey-prefix', valueHelp: '');
 
+    // Pgyer
+    argParser.addSeparator('pgyer');
+    argParser.addOption(
+      'pgyer-oversea',
+      valueHelp: '1|2',
+      help: 'Upload acceleration: 1=overseas, 2=domestic, empty=auto-detect',
+    );
+    argParser.addOption(
+      'pgyer-install-type',
+      valueHelp: '1|2|3',
+      help: 'Installation type: 1=public, 2=password, 3=invite (default: 1)',
+    );
+    argParser.addOption(
+      'pgyer-password',
+      valueHelp: '',
+      help: 'App installation password (required for password installation)',
+    );
+    argParser.addOption(
+      'pgyer-description',
+      valueHelp: '',
+      help: 'Application description (optional)',
+    );
+    argParser.addOption(
+      'pgyer-update-description',
+      valueHelp: '',
+      help: 'Version update description (optional)',
+    );
+    argParser.addOption(
+      'pgyer-install-date',
+      valueHelp: '1|2',
+      help: 'Installation validity: 1=set time, 2=permanent (optional)',
+    );
+    argParser.addOption(
+      'pgyer-install-start-date',
+      valueHelp: 'YYYY-MM-DD',
+      help: 'Installation validity start date (e.g., 2018-01-01)',
+    );
+    argParser.addOption(
+      'pgyer-install-end-date',
+      valueHelp: 'YYYY-MM-DD',
+      help: 'Installation validity end date (e.g., 2018-12-31)',
+    );
+    argParser.addOption(
+      'pgyer-channel-shortcut',
+      valueHelp: '',
+      help: 'Channel shortcut for update (e.g., abcd)',
+    );
+
     // PlayStore
     argParser.addSeparator('playstore');
     argParser.addOption('playstore-package-name', valueHelp: '');
@@ -244,6 +292,15 @@ class CommandPublish extends Command {
       'minio-region': argResults?['minio-region'],
       'minio-bucket': argResults?['minio-bucket'],
       'minio-savekey-prefix': argResults?['minio-savekey-prefix'],
+      'pgyer-oversea': argResults?['pgyer-oversea'],
+      'pgyer-install-type': argResults?['pgyer-install-type'],
+      'pgyer-password': argResults?['pgyer-password'],
+      'pgyer-description': argResults?['pgyer-description'],
+      'pgyer-update-description': argResults?['pgyer-update-description'],
+      'pgyer-install-date': argResults?['pgyer-install-date'],
+      'pgyer-install-start-date': argResults?['pgyer-install-start-date'],
+      'pgyer-install-end-date': argResults?['pgyer-install-end-date'],
+      'pgyer-channel-shortcut': argResults?['pgyer-channel-shortcut'],
       'playstore-package-name': argResults?['playstore-package-name'],
       'playstore-track': argResults?['playstore-track'],
       'qiniu-bucket': argResults?['qiniu-bucket'],


### PR DESCRIPTION
Description
Changes

Added support for the following optional parameters from pyger:
```
oversea: whether to use overseas accelerated upload (1 = overseas, 2 = domestic, empty = auto-detect by IP)

buildInstallType: app installation type (1 = public, 2 = password, 3 = invitation; default = 1)

buildPassword: installation password

buildDescription: app description

buildUpdateDescription: version update description

buildInstallDate: whether to set installation validity (1 = limited time, 2 = permanent)

buildInstallStartDate: installation validity start date (e.g. 2018-01-01)

buildInstallEndDate: installation validity end date (e.g. 2018-12-31)

buildChannelShortcut: specify the channel short link to be updated
```

Updated documentation to include the above parameters with examples.