### PR TITLE
feat: add prepackage/postpackage hooks support

### DIFF
--- a/apps/cli/src/cli/package.rs
+++ b/apps/cli/src/cli/package.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, anyhow};
+use std::process::Command;
 use clap::Args;
 use fastforge_app_builder::{FlutterAppBuilder, Platform};
 use fastforge_app_packager::{
@@ -6,6 +7,7 @@ use fastforge_app_packager::{
 };
 use serde::Deserialize;
 use serde_json::{Map, Value};
+use serde_yaml;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -20,6 +22,14 @@ pub struct PackageArgs {
     pub skip_clean: bool,
     #[arg(long = "build-target")]
     pub build_target: Option<String>,
+
+    /// Shell command to run before packaging.
+    #[arg(long = "hook-pre")]
+    pub hook_pre: Option<String>,
+
+    /// Shell command to run after packaging.
+    #[arg(long = "hook-post")]
+    pub hook_post: Option<String>,
 }
 
 pub async fn execute(args: &PackageArgs) -> Result<()> {
@@ -38,6 +48,18 @@ pub async fn execute(args: &PackageArgs) -> Result<()> {
         build_args.insert("target".to_string(), Value::String(value.clone()));
     }
 
+    // Build hooks map from CLI args
+    let hooks: Option<HashMap<String, serde_yaml::Value>> = {
+        let mut map = HashMap::new();
+        if let Some(cmd) = &args.hook_pre {
+            map.insert("pre".to_string(), serde_yaml::Value::String(cmd.clone()));
+        }
+        if let Some(cmd) = &args.hook_post {
+            map.insert("post".to_string(), serde_yaml::Value::String(cmd.clone()));
+        }
+        if map.is_empty() { None } else { Some(map) }
+    };
+
     let artifacts = package_flutter_artifact(
         platform,
         target,
@@ -46,6 +68,7 @@ pub async fn execute(args: &PackageArgs) -> Result<()> {
         "dist/",
         None,
         !args.skip_clean,
+        hooks.as_ref(),
     )?;
 
     for artifact in artifacts {
@@ -62,6 +85,7 @@ pub fn package_flutter_artifact(
     output: &str,
     artifact_name: Option<String>,
     clean_before_build: bool,
+    hooks: Option<&HashMap<String, serde_yaml::Value>>,
 ) -> Result<Vec<PathBuf>> {
     let platform = Platform::from_str(platform_str)
         .map_err(|e| anyhow!("Invalid platform '{}': {}", platform_str, e))?;
@@ -72,6 +96,9 @@ pub fn package_flutter_artifact(
             .clean(Some(&environment))
             .map_err(|e| anyhow!("{}", e))?;
     }
+
+    // Clone environment before it's moved into build()
+    let hook_env_base = environment.clone();
 
     let build = builder
         .build(&platform, Some(target), build_args, Some(environment))
@@ -105,10 +132,101 @@ pub fn package_flutter_artifact(
         ));
     }
 
+    // Resolve hooks: YAML allows both a single string and a list of strings
+    let pre_hooks = resolve_hooks(hooks, "pre");
+    let post_hooks = resolve_hooks(hooks, "post");
+
+    // Build hook environment
+    let mut hook_env = hook_env_base;
+    hook_env.insert(
+        "PLATFORM".to_string(),
+        package_config.platform.as_str().to_string(),
+    );
+    hook_env.insert(
+        "PACKAGE_FORMAT".to_string(),
+        package_config.package_format.clone(),
+    );
+    hook_env.insert(
+        "BUILD_MODE".to_string(),
+        package_config.build_mode.clone(),
+    );
+    hook_env.insert(
+        "OUTPUT_DIRECTORY".to_string(),
+        package_config.output_dir.to_string_lossy().to_string(),
+    );
+    hook_env.insert(
+        "BUILD_OUTPUT_DIRECTORY".to_string(),
+        package_config
+            .build_output_dir
+            .to_string_lossy()
+            .to_string(),
+    );
+    hook_env.insert(
+        "BUILD_OUTPUT_FILES".to_string(),
+        package_config
+            .build_output_files
+            .iter()
+            .map(|p| p.to_string_lossy().to_string())
+            .collect::<Vec<_>>()
+            .join(":"),
+    );
+
+    // Run prepackage hooks
+    run_hooks(&pre_hooks, &hook_env)?;
+
     let result = packager
         .package(&package_config)
         .map_err(|e| anyhow!("{}", e))?;
+
+    // Run postpackage hooks
+    run_hooks(&post_hooks, &hook_env)?;
+
     Ok(result.artifacts)
+}
+
+/// Extract and normalize hook commands for a given key ("pre" or "post").
+/// Supports both a single string and a list of strings.
+fn resolve_hooks(
+    hooks: Option<&HashMap<String, serde_yaml::Value>>,
+    key: &str,
+) -> Vec<String> {
+    let Some(hooks) = hooks else { return vec![] };
+    let Some(value) = hooks.get(key) else { return vec![] };
+    match value {
+        serde_yaml::Value::String(cmd) => vec![cmd.clone()],
+        serde_yaml::Value::Sequence(seq) => {
+            seq.iter().filter_map(|v| v.as_str().map(String::from)).collect()
+        }
+        _ => vec![],
+    }
+}
+
+/// Execute a list of shell hook commands.
+fn run_hooks(hooks: &[String], env: &HashMap<String, String>) -> Result<()> {
+    for hook in hooks {
+        let output = Command::new("sh")
+            .args(["-c", hook])
+            .envs(env)
+            .output()
+            .map_err(|e| anyhow!("Failed to execute hook '{}': {}", hook, e))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow!(
+                "Hook failed (exit {}): {}\n{}",
+                output.status.code().unwrap_or(-1),
+                hook,
+                stderr,
+            ));
+        }
+
+        // Print hook stdout so users can see the output
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !stdout.is_empty() {
+            print!("{}", stdout);
+        }
+    }
+    Ok(())
 }
 
 fn macos_packager(target: &str) -> Result<Box<dyn AppPackager + Send + Sync>> {

--- a/apps/cli/src/cli/release.rs
+++ b/apps/cli/src/cli/release.rs
@@ -132,6 +132,7 @@ pub async fn execute(args: &ReleaseArgs) -> Result<()> {
                 &opts.output,
                 opts.artifact_name.clone(),
                 !args.skip_clean,
+                job.package.hooks.as_ref(),
             )?;
 
             for artifact in &artifacts {

--- a/apps/cli/src/config/release.rs
+++ b/apps/cli/src/config/release.rs
@@ -47,6 +47,7 @@ mod tests {
                 target: "apk".to_string(),
                 channel: None,
                 build_args: None,
+                hooks: None,
             },
             publish: None,
             publish_to: None,

--- a/apps/cli/src/config/release_job.rs
+++ b/apps/cli/src/config/release_job.rs
@@ -10,6 +10,10 @@ pub struct ReleaseJobPackage {
     /// Build arguments passed to `flutter build`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build_args: Option<HashMap<String, serde_yaml::Value>>,
+    /// Package lifecycle hooks, e.g. `{ "pre": "echo before", "post": ["cmd1", "cmd2"] }`.
+    /// Values can be a single string or a list of strings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hooks: Option<HashMap<String, serde_yaml::Value>>,
 }
 
 /// Publish step of a release job.
@@ -59,6 +63,7 @@ mod tests {
                 target: "apk".to_string(),
                 channel: None,
                 build_args: None,
+                hooks: None,
             },
             publish: Some(ReleaseJobPublish {
                 target: "github".to_string(),
@@ -79,6 +84,7 @@ mod tests {
                 target: "ipa".to_string(),
                 channel: None,
                 build_args: None,
+                hooks: None,
             },
             publish: Some(ReleaseJobPublish {
                 target: "github".to_string(),
@@ -99,6 +105,7 @@ mod tests {
                 target: "dmg".to_string(),
                 channel: None,
                 build_args: None,
+                hooks: None,
             },
             publish: None,
             publish_to: None,

--- a/apps/docs/en/cli.md
+++ b/apps/docs/en/cli.md
@@ -16,12 +16,14 @@ dart pub global activate fastforge
 
 Will package your application into a platform specific format and put the result in a folder.
 
-<table><thead><tr><th>Flag</th><th>Value</th><th data-type="checkbox">Required</th></tr></thead><tbody><tr><td><code>--platform</code></td><td>Platform, e.g. <code>android</code></td><td>true</td></tr><tr><td><code>--targets</code></td><td>Comma separated list of maker names</td><td>true</td></tr><tr><td><code>--skip-clean</code></td><td>Skip clean once before build</td><td>false</td></tr></tbody></table>
+<table><thead><tr><th>Flag</th><th>Value</th><th data-type="checkbox">Required</th></tr></thead><tbody><tr><td><code>--platform</code></td><td>Platform, e.g. <code>android</code></td><td>true</td></tr><tr><td><code>--targets</code></td><td>Comma separated list of maker names</td><td>true</td></tr><tr><td><code>--skip-clean</code></td><td>Skip clean once before build</td><td>false</td></tr><tr><td><code>--hook-pre</code></td><td>Shell command to run before packaging</td><td>false</td></tr><tr><td><code>--hook-post</code></td><td>Shell command to run after packaging</td><td>false</td></tr></tbody></table>
 
 Example:
 
 ```
 fastforge package --platform=android --targets=aab,apk
+
+fastforge package --platform=macos --target=zip --hook-pre 'echo "before"' --hook-post 'echo "after"'
 ```
 
 ### Publish

--- a/apps/docs/en/distribute-options.md
+++ b/apps/docs/en/distribute-options.md
@@ -63,3 +63,53 @@ releases:
 | `env`      | `map`    | environment variables. |
 | `output`   | `string` | e.g. `dist/`           |
 | `releases` | -        | -                      |
+
+## Hooks
+
+Package hooks allow you to run shell commands before and after the packaging step of a job.
+
+### Example
+
+```yaml
+releases:
+  - name: dev
+    jobs:
+      - name: android-apk
+        package:
+          platform: android
+          target: apk
+          hooks:
+            pre: echo "Starting packaging..."
+            post:
+              - echo "Packaging complete!"
+              - ls -la dist/
+```
+
+### Specification
+
+Hooks are defined under `package.hooks` in a job. The value of each hook can be:
+
+| Type     | Example                                              |
+| -------- | ---------------------------------------------------- |
+| `string` | `pre: echo "before"`                                 |
+| `list`   | `post: [echo "step 1", echo "step 2"]`            |
+
+| Hook  | Description                    | Fail on error |
+| ----- | ------------------------------ | ------------- |
+| `pre` | Runs before packaging starts   | ✅ Yes        |
+| `post`| Runs after packaging completes | ✅ Yes        |
+
+> **Note**: If a hook command exits with a non-zero exit code, the packaging process is aborted.
+
+### Environment variables
+
+The following environment variables are available in hook commands:
+
+| Variable                | Description                                            |
+| ----------------------- | ------------------------------------------------------ |
+| `PLATFORM`              | Platform name, e.g. `android`, `ios`, `macos`          |
+| `PACKAGE_FORMAT`        | Package format, e.g. `apk`, `ipa`, `dmg`               |
+| `BUILD_MODE`            | Build mode, e.g. `release`, `profile`                  |
+| `OUTPUT_DIRECTORY`      | Output directory path                                  |
+| `BUILD_OUTPUT_DIRECTORY`| Flutter build output directory path                    |
+| `BUILD_OUTPUT_FILES`    | Colon-separated list of build output file paths        |

--- a/apps/docs/zh/cli.md
+++ b/apps/docs/zh/cli.md
@@ -16,12 +16,14 @@ dart pub global activate fastforge
 
 将应用程序打包为特定于平台的格式，并将结果放入文件夹中。
 
-<table><thead><tr><th>Flag</th><th>Value</th><th data-type="checkbox">Required</th></tr></thead><tbody><tr><td><code>--platform</code></td><td>平台, 如 <code>android</code></td><td>true</td></tr><tr><td><code>--targets</code></td><td>以逗号分隔的 maker 名称列表</td><td>true</td></tr><tr><td><code>--skip-clean</code></td><td>跳过构建前的清理</td><td>false</td></tr></tbody></table>
+<table><thead><tr><th>Flag</th><th>Value</th><th data-type="checkbox">Required</th></tr></thead><tbody><tr><td><code>--platform</code></td><td>平台, 如 <code>android</code></td><td>true</td></tr><tr><td><code>--targets</code></td><td>以逗号分隔的 maker 名称列表</td><td>true</td></tr><tr><td><code>--skip-clean</code></td><td>跳过构建前的清理</td><td>false</td></tr><tr><td><code>--hook-pre</code></td><td>打包前执行的 shell 命令</td><td>false</td></tr><tr><td><code>--hook-post</code></td><td>打包后执行的 shell 命令</td><td>false</td></tr></tbody></table>
 
 示例：
 
 ```shell
 fastforge package --platform=android --targets=aab,apk
+
+fastforge package --platform=macos --target=zip --hook-pre 'echo "before"' --hook-post 'echo "after"'
 ```
 
 ### Publish

--- a/apps/docs/zh/distribute-options.md
+++ b/apps/docs/zh/distribute-options.md
@@ -63,3 +63,53 @@ releases:
 | `env`      | `map`    | environment variables. |
 | `output`   | `string` | e.g. `dist/`           |
 | `releases` | -        | -                      |
+
+## Hooks
+
+Package hooks 允许你在 job 的打包步骤前后执行 shell 命令。
+
+### 示例
+
+```yaml
+releases:
+  - name: dev
+    jobs:
+      - name: android-apk
+        package:
+          platform: android
+          target: apk
+          hooks:
+            pre: echo "开始打包..."
+            post:
+              - echo "打包完成!"
+              - ls -la dist/
+```
+
+### 规范
+
+Hooks 定义在 job 的 `package.hooks` 下。每个 hook 的值可以是：
+
+| 类型     | 示例                                                |
+| -------- | ---------------------------------------------------- |
+| `string` | `pre: echo "before"`                                 |
+| `list`   | `post: [echo "step 1", echo "step 2"]`            |
+
+| Hook   | 描述               | 失败时终止 |
+| ------ | ------------------ | ---------- |
+| `pre`  | 打包前执行         | ✅ 是      |
+| `post` | 打包完成后执行     | ✅ 是      |
+
+> **注意**：如果 hook 命令返回非零退出码，打包过程将被终止。
+
+### 环境变量
+
+以下环境变量可在 hook 命令中使用：
+
+| 变量                     | 说明                                            |
+| ------------------------ | ----------------------------------------------- |
+| `PLATFORM`               | 平台名称，如 `android`、`ios`、`macos`          |
+| `PACKAGE_FORMAT`         | 包格式，如 `apk`、`ipa`、`dmg`                  |
+| `BUILD_MODE`             | 构建模式，如 `release`、`profile`               |
+| `OUTPUT_DIRECTORY`       | 输出目录路径                                    |
+| `BUILD_OUTPUT_DIRECTORY` | Flutter 构建产物输出目录路径                    |
+| `BUILD_OUTPUT_FILES`     | 冒号分隔的构建产物文件路径列表                  |

--- a/examples/hello_world/android/gradle.properties
+++ b/examples/hello_world/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/examples/hello_world/distribute_options.yaml
+++ b/examples/hello_world/distribute_options.yaml
@@ -16,6 +16,9 @@ releases:
           target: apk
           build_args:
             target-platform: android-arm,android-arm64
+          hooks:
+            pre: 'echo "[HOOK] prepackage: platform=$PLATFORM, build_output=$BUILD_OUTPUT_DIRECTORY"'
+            post: 'echo "[HOOK] postpackage: output=$OUTPUT_DIRECTORY, files=$BUILD_OUTPUT_FILES"'
       - name: ios-ipa
         package:
           platform: ios

--- a/packages/flutter_app_packager/lib/src/api/make_config.dart
+++ b/packages/flutter_app_packager/lib/src/api/make_config.dart
@@ -24,6 +24,12 @@ class MakeConfig {
   late String packageFormat;
   late Directory outputDirectory;
 
+  /// Shell commands to run before packaging.
+  List<String>? prepackageHooks;
+
+  /// Shell commands to run after packaging.
+  List<String>? postpackageHooks;
+
   String get appName => pubspec.name;
   String get appBinaryName => pubspec.name;
   Version get appVersion => pubspec.version!;
@@ -46,6 +52,8 @@ class MakeConfig {
     artifactName = makeConfig.artifactName;
     packageFormat = makeConfig.packageFormat;
     outputDirectory = makeConfig.outputDirectory;
+    prepackageHooks = makeConfig.prepackageHooks;
+    postpackageHooks = makeConfig.postpackageHooks;
     return this;
   }
 
@@ -163,7 +171,7 @@ class DefaultMakeConfigLoader extends MakeConfigLoader {
     required Directory buildOutputDirectory,
     required List<File> buildOutputFiles,
   }) {
-    return MakeConfig()
+    final config = MakeConfig()
       ..platform = platform
       ..buildMode = arguments?['build_mode']
       ..buildOutputDirectory = buildOutputDirectory
@@ -173,6 +181,24 @@ class DefaultMakeConfigLoader extends MakeConfigLoader {
       ..artifactName = arguments?['artifact_name']
       ..packageFormat = packageFormat
       ..outputDirectory = outputDirectory;
+
+    // Parse hooks from arguments
+    if (arguments?['hooks'] != null) {
+      final hooks = Map<String, dynamic>.from(arguments!['hooks']);
+      config.prepackageHooks = _normalizeHookList(hooks['pre']);
+      config.postpackageHooks = _normalizeHookList(hooks['post']);
+    }
+
+    return config;
+  }
+
+  /// Normalize a hook value to [List<String>].
+  /// Supports both a single string and a list of strings.
+  List<String>? _normalizeHookList(dynamic value) {
+    if (value == null) return null;
+    if (value is String) return [value];
+    if (value is List) return value.cast<String>();
+    return null;
   }
 }
 

--- a/packages/flutter_app_packager/lib/src/flutter_app_packager.dart
+++ b/packages/flutter_app_packager/lib/src/flutter_app_packager.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_app_packager/src/api/app_package_maker.dart';
 import 'package:flutter_app_packager/src/makers/makers.dart';
 import 'package:flutter_app_packager/src/makers/pacman/app_package_maker_pacman.dart';
+import 'package:shell_executor/shell_executor.dart';
 
 class FlutterAppPackager {
   final List<AppPackageMaker> _makers = [
@@ -42,7 +43,7 @@ class FlutterAppPackager {
     Directory outputDirectory, {
     required Directory buildOutputDirectory,
     required List<File> buildOutputFiles,
-  }) {
+  }) async {
     final maker = _makers.firstWhere((e) => e.match(platform, target));
     final config = maker.configLoader.load(
       arguments,
@@ -50,6 +51,40 @@ class FlutterAppPackager {
       buildOutputDirectory: buildOutputDirectory,
       buildOutputFiles: buildOutputFiles,
     );
-    return maker.make(config);
+
+    // Run prepackage hooks
+    await _runHooks(config.prepackageHooks, config);
+
+    final result = await maker.make(config);
+
+    // Run postpackage hooks
+    await _runHooks(config.postpackageHooks, config);
+
+    return result;
+  }
+
+  /// Execute a list of shell hook commands.
+  Future<void> _runHooks(List<String>? hooks, MakeConfig config) async {
+    if (hooks == null || hooks.isEmpty) return;
+    for (final hook in hooks) {
+      final result = await $(
+        'sh',
+        ['-c', hook],
+        environment: {
+          'PLATFORM': config.platform,
+          'PACKAGE_FORMAT': config.packageFormat,
+          'BUILD_MODE': config.buildMode,
+          'OUTPUT_DIRECTORY': config.outputDirectory.path,
+          'BUILD_OUTPUT_DIRECTORY': config.buildOutputDirectory.path,
+          'BUILD_OUTPUT_FILES':
+              config.buildOutputFiles.map((f) => f.path).join(':'),
+        },
+      );
+      if (result.exitCode != 0) {
+        throw Exception(
+          'Hook failed (exit ${result.exitCode}): $hook\n${result.stderr}',
+        );
+      }
+    }
   }
 }

--- a/packages/unified_distributor/lib/src/cli/command_package.dart
+++ b/packages/unified_distributor/lib/src/cli/command_package.dart
@@ -84,6 +84,18 @@ class CommandPackage extends Command {
       help: 'The --export-options-plist argument passed \'flutter build\'',
     );
 
+    argParser.addOption(
+      'hook-pre',
+      valueHelp: '',
+      help: 'Shell command to run before packaging.',
+    );
+
+    argParser.addOption(
+      'hook-post',
+      valueHelp: '',
+      help: 'Shell command to run after packaging.',
+    );
+
     argParser.addMultiOption(
       'build-dart-define',
       valueHelp: 'foo=bar',
@@ -118,6 +130,8 @@ class CommandPackage extends Command {
     final String? artifactName = argResults?['artifact-name'];
     final String? flutterBuildArgs = argResults?['flutter-build-args'];
     final bool isSkipClean = argResults?.wasParsed('skip-clean') ?? false;
+    final String? hookPre = argResults?['hook-pre'];
+    final String? hookPost = argResults?['hook-post'];
     final Map<String, dynamic> buildArguments =
         _generateBuildArgs(flutterBuildArgs);
 
@@ -132,6 +146,15 @@ class CommandPackage extends Command {
       exit(1);
     }
 
+    final Map<String, dynamic>? hooks;
+    if (hookPre != null || hookPost != null) {
+      hooks = {};
+      if (hookPre != null) hooks['pre'] = hookPre;
+      if (hookPost != null) hooks['post'] = hookPost;
+    } else {
+      hooks = null;
+    }
+
     return distributor.package(
       platform,
       targets,
@@ -139,6 +162,7 @@ class CommandPackage extends Command {
       artifactName: artifactName,
       cleanBeforeBuild: !isSkipClean,
       buildArguments: buildArguments,
+      hooks: hooks,
     );
   }
 

--- a/packages/unified_distributor/lib/src/release_job.dart
+++ b/packages/unified_distributor/lib/src/release_job.dart
@@ -4,14 +4,20 @@ class ReleaseJobPackage {
     required this.target,
     this.channel,
     this.buildArgs,
+    this.hooks,
   });
 
   factory ReleaseJobPackage.fromJson(Map<String, dynamic> json) {
+    Map<String, dynamic>? hooks;
+    if (json.containsKey('hooks') && json['hooks'] != null) {
+      hooks = Map<String, dynamic>.from(json['hooks']);
+    }
     return ReleaseJobPackage(
       platform: json['platform'],
       target: json['target'],
       channel: json['channel'],
       buildArgs: json['build_args'],
+      hooks: hooks,
     );
   }
 
@@ -20,12 +26,16 @@ class ReleaseJobPackage {
   final String? channel;
   final Map<String, dynamic>? buildArgs;
 
+  /// Package lifecycle hooks, e.g. `{ "pre": "...", "post": "..." }`
+  final Map<String, dynamic>? hooks;
+
   Map<String, dynamic> toJson() {
     return {
       'platform': platform,
       'target': target,
       'channel': channel,
       'build_args': buildArgs,
+      'hooks': hooks,
     }..removeWhere((key, value) => value == null);
   }
 }

--- a/packages/unified_distributor/lib/src/unified_distributor.dart
+++ b/packages/unified_distributor/lib/src/unified_distributor.dart
@@ -144,6 +144,7 @@ class UnifiedDistributor {
     required bool cleanBeforeBuild,
     required Map<String, dynamic> buildArguments,
     Map<String, String>? variables,
+    Map<String, dynamic>? hooks,
   }) async {
     // Pass environment variables (e.g. INNO_SETUP_PATH) to the packager via static setter
     if (variables != null && variables.isNotEmpty) {
@@ -199,6 +200,9 @@ class UnifiedDistributor {
             'channel': channel,
             'artifact_name': artifactName,
           };
+          if (hooks != null) {
+            arguments['hooks'] = hooks;
+          }
           MakeResult makeResult = await _packager.package(
             platform,
             target,
@@ -376,6 +380,7 @@ class UnifiedDistributor {
             cleanBeforeBuild: needCleanBeforeBuild,
             buildArguments: job.package.buildArgs ?? {},
             variables: variables,
+            hooks: job.package.hooks,
           );
           // Clean only once
           needCleanBeforeBuild = false;


### PR DESCRIPTION
## Description

Add package lifecycle hooks (pre/post) for the packaging step, allowing users to run shell commands before and after packaging.

## Changes

### Dart (旧 CLI)
- `FlutterAppPackager` — 在 `maker.make()` 前后执行 prepackage/postpackage hooks
- `CommandPackage` — 新增 `--hook-pre` / `--hook-post` CLI 参数
- `ReleaseJobPackage` — 新增 `hooks` 字段，支持 YAML 配置
- `MakeConfig` — 新增 `prepackageHooks` / `postpackageHooks`

### Rust (新 CLI)
- `package_flutter_artifact()` — 新增 `hooks` 参数，在 `packager.package()` 前后执行
- `PackageArgs` — 新增 `--hook-pre` / `--hook-post` CLI 参数
- `ReleaseJobPackage` — 新增 `hooks` 字段

### Config (YAML)
```yaml
package:
  platform: android
  target: apk
  hooks:
    pre: echo "before"
    post:
      - echo "step 1"
      - echo "step 2"
```

### CLI
```bash
fastforge package --platform macos --target zip --hook-pre "echo before" --hook-post "echo after"
```

### Environment variables
`PLATFORM`, `PACKAGE_FORMAT`, `BUILD_MODE`, `OUTPUT_DIRECTORY`, `BUILD_OUTPUT_DIRECTORY`, `BUILD_OUTPUT_FILES`

## Related Issues
Closes #59
Closes #288