### PR TITLE
fix: ensure non-zero exit code on packaging/publishing errors

### DIFF
--- a/packages/fastforge/bin/main.dart
+++ b/packages/fastforge/bin/main.dart
@@ -1,11 +1,19 @@
+import 'dart:io';
+
 import 'package:unified_distributor/unified_distributor.dart';
 
 Future<void> main(List<String> args) async {
-  final cli = UnifiedDistributorCommandLineInterface(
-    'fastforge',
-    'Package and publish your apps with ease.',
-    packageName: 'fastforge',
-    displayName: 'Fastforge',
-  );
-  return await cli.run(args);
+  try {
+    final cli = UnifiedDistributorCommandLineInterface(
+      'fastforge',
+      'Package and publish your apps with ease.',
+      packageName: 'fastforge',
+      displayName: 'Fastforge',
+    );
+    await cli.run(args);
+  } catch (error, stackTrace) {
+    stderr.writeln(error.toString());
+    stderr.writeln(stackTrace.toString());
+    exit(1);
+  }
 }

--- a/packages/flutter_app_packager/lib/src/makers/pkg/app_package_maker_pkg.dart
+++ b/packages/flutter_app_packager/lib/src/makers/pkg/app_package_maker_pkg.dart
@@ -45,7 +45,14 @@ class AppPackageMakerPkg extends AppPackageMaker {
       pkgBuild.add(makeConfig.scriptsPath!);
     }
 
-    await $('xcrun', pkgBuild);
+    await $('xcrun', pkgBuild).then((result) {
+      if (result.exitCode != 0) {
+        throw MakeError(
+          'productbuild failed with exit code ${result.exitCode}: '
+          '${result.stderr ?? result.stdout}',
+        );
+      }
+    });
 
     // 修复 pkg 元数据：expand → 编辑 → flatten
     // productbuild --component 生成的包有两个问题：
@@ -53,7 +60,16 @@ class AppPackageMakerPkg extends AppPackageMaker {
     // 2. 组件 PackageInfo 包含 <relocate>，导致安装器重定向到已存在的构建产物
     final expandDir = Directory('${unsignedPkgFile.path}.expanded');
     if (expandDir.existsSync()) expandDir.deleteSync(recursive: true);
-    await $('pkgutil', ['--expand', unsignedPkgFile.path, expandDir.path]);
+    await $('pkgutil', ['--expand', unsignedPkgFile.path, expandDir.path]).then(
+      (result) {
+        if (result.exitCode != 0) {
+          throw MakeError(
+            'pkgutil --expand failed with exit code ${result.exitCode}: '
+            '${result.stderr ?? result.stdout}',
+          );
+        }
+      },
+    );
 
     // 修复 1：Distribution 注入 <domains>
     final distributionFile = File('${expandDir.path}/Distribution');
@@ -85,7 +101,16 @@ class AppPackageMakerPkg extends AppPackageMaker {
     }
 
     unsignedPkgFile.deleteSync();
-    await $('pkgutil', ['--flatten', expandDir.path, unsignedPkgFile.path]);
+    await $('pkgutil', ['--flatten', expandDir.path, unsignedPkgFile.path]).then(
+      (result) {
+        if (result.exitCode != 0) {
+          throw MakeError(
+            'pkgutil --flatten failed with exit code ${result.exitCode}: '
+            '${result.stderr ?? result.stdout}',
+          );
+        }
+      },
+    );
     expandDir.deleteSync(recursive: true);
     if (makeConfig.signIdentity != null) {
       final ProcessResult signResult = await $('xcrun', [

--- a/packages/flutter_distributor/bin/main.dart
+++ b/packages/flutter_distributor/bin/main.dart
@@ -1,11 +1,19 @@
+import 'dart:io';
+
 import 'package:unified_distributor/unified_distributor.dart';
 
 Future<void> main(List<String> args) async {
-  final cli = UnifiedDistributorCommandLineInterface(
-    'flutter_distributor',
-    'Package and publish your apps with ease.',
-    packageName: 'flutter_distributor',
-    displayName: 'Flutter Distributor',
-  );
-  return await cli.run(args);
+  try {
+    final cli = UnifiedDistributorCommandLineInterface(
+      'flutter_distributor',
+      'Package and publish your apps with ease.',
+      packageName: 'flutter_distributor',
+      displayName: 'Flutter Distributor',
+    );
+    await cli.run(args);
+  } catch (error, stackTrace) {
+    stderr.writeln(error.toString());
+    stderr.writeln(stackTrace.toString());
+    exit(1);
+  }
 }

--- a/packages/unified_distributor/lib/src/unified_distributor.dart
+++ b/packages/unified_distributor/lib/src/unified_distributor.dart
@@ -304,9 +304,13 @@ class UnifiedDistributor {
         );
         publishResultList.add(publishResult);
       }
-    } on Error catch (error) {
+    } catch (error, stackTrace) {
       logger.severe(error.toString().brightRed());
-      logger.severe(error.stackTrace.toString().brightRed());
+      if (error is Error) {
+        logger.severe(error.stackTrace.toString().brightRed());
+      } else {
+        logger.severe(stackTrace.toString().brightRed());
+      }
       rethrow;
     }
     return publishResultList;


### PR DESCRIPTION
## 问题

修复 #344 — 打包/发布出错时，工具退出码为 0，导致 CI 系统无法检测到失败。

## 根本原因分析

### 1. `bin/main.dart` 缺少顶层错误处理（主要修复）

`fastforge` 和 `flutter_distributor` 的入口函数没有 try-catch，只是直接 `return await cli.run(args)`。当异常传播到 `main()` 时，虽然 Dart 理论上会以非零退出码退出，但在某些调用方式下（如 `dart pub global run`）行为不稳定。新增显式 `exit(1)` 确保 CI 始终收到非零退出码。

### 2. `publish()` 方法仅捕获 `Error`，不捕获 `Exception`

`unified_distributor.dart` 中 `publish()` 使用 `on Error catch`，导致 `DioException`、`IOException` 等 `Exception` 子类绕过日志记录（虽然异常仍会继续传播）。改为通用 `catch` 确保所有异常都被记录后再重新抛出。

### 3. `pkg` maker 未检查子进程退出码

`app_package_maker_pkg.dart` 中以下命令未检查退出码，失败时静默继续执行：
- `xcrun productbuild`
- `pkgutil --expand`
- `pkgutil --flatten`

现在在每个命令失败时抛出带有详细信息的 `MakeError`。

## 变更文件

- `packages/fastforge/bin/main.dart` — 顶层 try-catch + exit(1)
- `packages/flutter_distributor/bin/main.dart` — 同上
- `packages/unified_distributor/lib/src/unified_distributor.dart` — publish() 改为通用 catch
- `packages/flutter_app_packager/lib/src/makers/pkg/app_package_maker_pkg.dart` — 检查 productbuild/pkgutil 退出码