### PR TITLE
[codex] fix desktop entry version key

### DIFF
--- a/packages/flutter_app_packager/lib/src/makers/deb/make_deb_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/deb/make_deb_config.dart
@@ -298,7 +298,6 @@ class MakeDebConfig extends MakeLinuxPackageConfig {
       }..removeWhere((key, value) => value == null),
       'DESKTOP': {
         'Type': 'Application',
-        'Version': appVersion.toString(),
         'Name': displayName,
         'GenericName': genericName,
         'Icon': appBinaryName,

--- a/packages/flutter_app_packager/lib/src/makers/pacman/make_pacman_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/pacman/make_pacman_config.dart
@@ -246,7 +246,6 @@ class MakePacmanConfig extends MakeLinuxPackageConfig {
       }..removeWhere((key, value) => value == null),
       'DESKTOP': {
         'Type': 'Application',
-        'Version': appVersion.toString(),
         'Name': displayName,
         'GenericName': genericName,
         'Icon': appBinaryName,

--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -157,7 +157,6 @@ class MakeRPMConfig extends MakeConfig {
       },
       'DESKTOP': {
         'Type': 'Application',
-        'Version': appVersion.toString(),
         'Name': displayName,
         'GenericName': genericName,
         'Icon': appName,

--- a/packages/flutter_app_packager/test/src/makers/linux_desktop_entry_test.dart
+++ b/packages/flutter_app_packager/test/src/makers/linux_desktop_entry_test.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:flutter_app_packager/src/makers/deb/make_deb_config.dart';
+import 'package:flutter_app_packager/src/makers/pacman/make_pacman_config.dart';
+import 'package:flutter_app_packager/src/makers/rpm/make_rpm_config.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Linux desktop entry files', () {
+    late Directory originalCurrent;
+    late Directory tempDir;
+
+    setUp(() {
+      originalCurrent = Directory.current;
+      tempDir = Directory.systemTemp.createTempSync('fastforge_desktop_test_');
+      Directory('${tempDir.path}/linux').createSync(recursive: true);
+      File('${tempDir.path}/linux/CMakeLists.txt')
+          .writeAsStringSync('set(BINARY_NAME "test_app")\n');
+      Directory.current = tempDir;
+    });
+
+    tearDown(() {
+      Directory.current = originalCurrent;
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('deb keeps package version out of the desktop entry', () {
+      final config = MakeDebConfig(
+        displayName: 'Test App',
+        packageName: 'test-app',
+        installedSize: 42,
+        maintainer: 'Maintainer <maintainer@example.com>',
+      )..pubspec = _pubspec();
+
+      final files = config.toFilesString();
+
+      expect(files['CONTROL'], contains('Version: 1.2.3+4'));
+      expect(files['DESKTOP'], isNot(contains('\nVersion=')));
+    });
+
+    test('rpm keeps package version out of the desktop entry', () {
+      final config = MakeRPMConfig(
+        displayName: 'Test App',
+      )..pubspec = _pubspec();
+
+      final files = config.toFilesString();
+
+      expect(files['SPEC'], contains('Version: 1.2.3+4'));
+      expect(files['DESKTOP'], isNot(contains('\nVersion=')));
+    });
+
+    test('pacman keeps package version out of the desktop entry', () {
+      final config = MakePacmanConfig(
+        displayName: 'Test App',
+        packageName: 'test-app',
+        maintainer: 'Maintainer <maintainer@example.com>',
+      )..pubspec = _pubspec();
+
+      final files = config.toFilesString();
+
+      expect(files['PKGINFO'], contains('pkgver=1.2.3+4'));
+      expect(files['DESKTOP'], isNot(contains('\nVersion=')));
+    });
+  });
+}
+
+Pubspec _pubspec() {
+  return Pubspec(
+    'test_app',
+    version: Version.parse('1.2.3+4'),
+    description: 'Test app',
+    homepage: 'https://example.com',
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #213 by removing the application version from generated Linux desktop entry files. The Freedesktop Desktop Entry Specification defines the Version key as the desktop entry spec version, and the key is optional.

## Changes

- Remove Version from generated .desktop files for deb, rpm, and pacman packages.
- Keep package versions in Debian control, RPM spec, and Pacman PKGINFO metadata.
- Add regression tests covering all three Linux package generators.

## Validation

- dart test