### PR TITLE
feat(exe): add configurable architecture support for Inno Setup installer

### DIFF
--- a/apps/docs/en/makers/exe.md
+++ b/apps/docs/en/makers/exe.md
@@ -28,13 +28,13 @@ locales:
   - zh
 # Space-separated list of architecture identifiers the installer is allowed to run on.
 # See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed
-# Defaults to `x64` if not specified.
-# architectures_allowed: x64
+# Defaults to `x64compatible` if not specified.
+# architectures_allowed: x64compatible
 
 # Space-separated list of architectures that should enable 64-bit install mode.
 # See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode
-# Defaults to `x64` if not specified.
-# architectures_install_in_64bit_mode: x64
+# Defaults to `x64compatible` if not specified.
+# architectures_install_in_64bit_mode: x64compatible
 ```
 
 Run:
@@ -63,7 +63,7 @@ If `INNO_SETUP_PATH` is not set, `fastforge` will check the default path first, 
 
 ### Target Architecture
 
-By default, the generated installer only allows installation on **x64** (64-bit x86) systems. You can customize this behavior using the `architectures_allowed` and `architectures_install_in_64bit_mode` options to support additional architectures like ARM64.
+By default, the generated installer allows installation on **x64-compatible systems** (both native x64 and ARM64 with x64 emulation). You can customize this behavior using the `architectures_allowed` and `architectures_install_in_64bit_mode` options.
 
 ```yaml
 # Allow installation on both x64 and ARM64 systems
@@ -76,7 +76,7 @@ architectures_install_in_64bit_mode: x64compatible
 
 Common architecture identifiers: `x86`, `x64`, `arm64`, `x64compatible`, `x86compatible`. Note that `x64compatible` matches both native x64 systems and ARM64 systems running x64 emulation (e.g., Windows 11 on ARM), while `x64` only matches native x64 hardware.
 
-If not specified, both options default to `x64`, preserving backward compatibility.
+If not specified, both options default to `x64compatible`.
 
 ### Custom Inno Setup Template
 

--- a/apps/docs/en/makers/exe.md
+++ b/apps/docs/en/makers/exe.md
@@ -26,12 +26,12 @@ create_desktop_icon: true
 locales:
   - en
   - zh
-# Comma-separated list of architectures the installer is allowed to run on.
+# Space-separated list of architecture identifiers the installer is allowed to run on.
 # See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed
 # Defaults to `x64` if not specified.
 # architectures_allowed: x64
 
-# Comma-separated list of 64-bit architectures that trigger 64-bit install mode.
+# Space-separated list of architectures that should enable 64-bit install mode.
 # See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode
 # Defaults to `x64` if not specified.
 # architectures_install_in_64bit_mode: x64
@@ -67,12 +67,14 @@ By default, the generated installer only allows installation on **x64** (64-bit 
 
 ```yaml
 # Allow installation on both x64 and ARM64 systems
-architectures_allowed: x64 arm64
-architectures_install_in_64bit_mode: x64 arm64
+architectures_allowed: x64compatible
+architectures_install_in_64bit_mode: x64compatible
 ```
 
-- `architectures_allowed` — Specifies which CPU architectures the installer is allowed to run on. See the [Inno Setup documentation](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed) for available values.
-- `architectures_install_in_64bit_mode` — Specifies which architectures should trigger 64-bit installation mode (e.g., `{autopf64}` for default install directory). See the [Inno Setup documentation](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode) for available values.
+- `architectures_allowed` — Specifies which CPU architectures the installer is allowed to run on. Values are space-separated architecture identifiers or boolean expressions. See the [Inno Setup documentation](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed) for available values.
+- `architectures_install_in_64bit_mode` — Specifies which architectures should enable 64-bit install mode (e.g., `{autopf64}` for default install directory). Values are space-separated architecture identifiers or boolean expressions. See the [Inno Setup documentation](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode) for available values.
+
+Common architecture identifiers: `x86`, `x64`, `arm64`, `x64compatible`, `x86compatible`. Note that `x64compatible` matches both native x64 systems and ARM64 systems running x64 emulation (e.g., Windows 11 on ARM), while `x64` only matches native x64 hardware.
 
 If not specified, both options default to `x64`, preserving backward compatibility.
 

--- a/apps/docs/en/makers/exe.md
+++ b/apps/docs/en/makers/exe.md
@@ -26,6 +26,15 @@ create_desktop_icon: true
 locales:
   - en
   - zh
+# Comma-separated list of architectures the installer is allowed to run on.
+# See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed
+# Defaults to `x64` if not specified.
+# architectures_allowed: x64
+
+# Comma-separated list of 64-bit architectures that trigger 64-bit install mode.
+# See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode
+# Defaults to `x64` if not specified.
+# architectures_install_in_64bit_mode: x64
 ```
 
 Run:
@@ -51,6 +60,21 @@ fastforge package --platform windows --targets exe
 ```
 
 If `INNO_SETUP_PATH` is not set, `fastforge` will check the default path first, then fall back to looking for `iscc` in your system `PATH` (which is useful when Inno Setup is installed via Scoop or added to PATH manually).
+
+### Target Architecture
+
+By default, the generated installer only allows installation on **x64** (64-bit x86) systems. You can customize this behavior using the `architectures_allowed` and `architectures_install_in_64bit_mode` options to support additional architectures like ARM64.
+
+```yaml
+# Allow installation on both x64 and ARM64 systems
+architectures_allowed: x64 arm64
+architectures_install_in_64bit_mode: x64 arm64
+```
+
+- `architectures_allowed` — Specifies which CPU architectures the installer is allowed to run on. See the [Inno Setup documentation](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed) for available values.
+- `architectures_install_in_64bit_mode` — Specifies which architectures should trigger 64-bit installation mode (e.g., `{autopf64}` for default install directory). See the [Inno Setup documentation](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode) for available values.
+
+If not specified, both options default to `x64`, preserving backward compatibility.
 
 ### Custom Inno Setup Template
 

--- a/apps/docs/zh/makers/exe.md
+++ b/apps/docs/zh/makers/exe.md
@@ -26,12 +26,12 @@ create_desktop_icon: true
 locales:
   - en
   - zh
-# 允许安装程序运行的 CPU 架构列表（逗号分隔）。
+# 允许安装程序运行的 CPU 架构标识符列表（空格分隔）。
 # 参见：https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed
 # 默认值为 `x64`。
 # architectures_allowed: x64
 
-# 触发 64 位安装模式的架构列表（逗号分隔）。
+# 触发 64 位安装模式的架构标识符列表（空格分隔）。
 # 参见：https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode
 # 默认值为 `x64`。
 # architectures_install_in_64bit_mode: x64
@@ -67,12 +67,14 @@ fastforge package --platform windows --targets exe
 
 ```yaml
 # 允许在 x64 和 ARM64 系统上安装
-architectures_allowed: x64 arm64
-architectures_install_in_64bit_mode: x64 arm64
+architectures_allowed: x64compatible
+architectures_install_in_64bit_mode: x64compatible
 ```
 
-- `architectures_allowed` — 指定允许安装程序运行的 CPU 架构。参见 [Inno Setup 文档](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed) 了解可用值。
-- `architectures_install_in_64bit_mode` — 指定应触发 64 位安装模式的架构（例如默认安装目录 `{autopf64}`）。参见 [Inno Setup 文档](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode) 了解可用值。
+- `architectures_allowed` — 指定允许安装程序运行的 CPU 架构。值为空格分隔的架构标识符或布尔表达式。参见 [Inno Setup 文档](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed) 了解可用值。
+- `architectures_install_in_64bit_mode` — 指定应触发 64 位安装模式的架构（例如默认安装目录 `{autopf64}`）。值为空格分隔的架构标识符或布尔表达式。参见 [Inno Setup 文档](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode) 了解可用值。
+
+常用架构标识符：`x86`、`x64`、`arm64`、`x64compatible`、`x86compatible`。其中 `x64compatible` 会匹配原生 x64 系统和运行 x64 模拟的 ARM64 系统（如 Windows 11 on ARM），而 `x64` 仅匹配原生 x64 硬件。
 
 如果未指定，这两个选项默认值均为 `x64`，保持向后兼容。
 

--- a/apps/docs/zh/makers/exe.md
+++ b/apps/docs/zh/makers/exe.md
@@ -26,6 +26,15 @@ create_desktop_icon: true
 locales:
   - en
   - zh
+# 允许安装程序运行的 CPU 架构列表（逗号分隔）。
+# 参见：https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed
+# 默认值为 `x64`。
+# architectures_allowed: x64
+
+# 触发 64 位安装模式的架构列表（逗号分隔）。
+# 参见：https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode
+# 默认值为 `x64`。
+# architectures_install_in_64bit_mode: x64
 ```
 
 运行：
@@ -52,9 +61,24 @@ fastforge package --platform windows --targets exe
 
 如果没有设置 `INNO_SETUP_PATH`，`fastforge` 会先检查默认路径，然后回退到在系统 `PATH` 中查找 `iscc`（适用于通过 Scoop 安装或手动将 Inno Setup 添加到 PATH 的场景）。
 
+### 目标架构
+
+默认情况下，生成的安装程序仅允许在 **x64**（64 位 x86）系统上安装。你可以通过 `architectures_allowed` 和 `architectures_install_in_64bit_mode` 选项自定义此行为，以支持其他架构（如 ARM64）。
+
+```yaml
+# 允许在 x64 和 ARM64 系统上安装
+architectures_allowed: x64 arm64
+architectures_install_in_64bit_mode: x64 arm64
+```
+
+- `architectures_allowed` — 指定允许安装程序运行的 CPU 架构。参见 [Inno Setup 文档](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed) 了解可用值。
+- `architectures_install_in_64bit_mode` — 指定应触发 64 位安装模式的架构（例如默认安装目录 `{autopf64}`）。参见 [Inno Setup 文档](https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode) 了解可用值。
+
+如果未指定，这两个选项默认值均为 `x64`，保持向后兼容。
+
 ### 自定义 Inno Setup 模板
 
-默认情况下，`fastforge` 会在构建时基于内部模板生成一个 Inno Setup 配置（`.iss`），并将其填充到 `make_config.yaml` 中提供的值。如果你需要对 Inno Setup 配置进行更多控制，你可以使用 `script_template` 选项提供一个自定义模板。
+默认情况下，`fastforge` 会在构建时基于内部模板生成一个 Inno Setup 配置（`.iss`），并填充 `make_config.yaml` 中提供的值。如果你需要对 Inno Setup 配置进行更多控制，可以使用 `script_template` 选项提供自定义模板。
 
 例如：
 

--- a/apps/docs/zh/makers/exe.md
+++ b/apps/docs/zh/makers/exe.md
@@ -28,13 +28,13 @@ locales:
   - zh
 # 允许安装程序运行的 CPU 架构标识符列表（空格分隔）。
 # 参见：https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed
-# 默认值为 `x64`。
-# architectures_allowed: x64
+# 默认值为 `x64compatible`。
+# architectures_allowed: x64compatible
 
 # 触发 64 位安装模式的架构标识符列表（空格分隔）。
 # 参见：https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode
-# 默认值为 `x64`。
-# architectures_install_in_64bit_mode: x64
+# 默认值为 `x64compatible`。
+# architectures_install_in_64bit_mode: x64compatible
 ```
 
 运行：
@@ -63,7 +63,7 @@ fastforge package --platform windows --targets exe
 
 ### 目标架构
 
-默认情况下，生成的安装程序仅允许在 **x64**（64 位 x86）系统上安装。你可以通过 `architectures_allowed` 和 `architectures_install_in_64bit_mode` 选项自定义此行为，以支持其他架构（如 ARM64）。
+默认情况下，生成的安装程序允许在 **x64 兼容的系统**上安装（包括原生 x64 和带 x64 模拟的 ARM64 系统）。你可以通过 `architectures_allowed` 和 `architectures_install_in_64bit_mode` 选项自定义此行为。
 
 ```yaml
 # 允许在 x64 和 ARM64 系统上安装
@@ -76,7 +76,7 @@ architectures_install_in_64bit_mode: x64compatible
 
 常用架构标识符：`x86`、`x64`、`arm64`、`x64compatible`、`x86compatible`。其中 `x64compatible` 会匹配原生 x64 系统和运行 x64 模拟的 ARM64 系统（如 Windows 11 on ARM），而 `x64` 仅匹配原生 x64 硬件。
 
-如果未指定，这两个选项默认值均为 `x64`，保持向后兼容。
+如果未指定，这两个选项默认值均为 `x64compatible`。
 
 ### 自定义 Inno Setup 模板
 

--- a/examples/hello_world/windows/packaging/exe/make_config.yaml
+++ b/examples/hello_world/windows/packaging/exe/make_config.yaml
@@ -9,9 +9,9 @@ launch_at_startup: true
 locales:
   - zh
 # Space-separated list of architecture identifiers the installer is allowed to run on.
-# Defaults to `x64` if not specified.
-# architectures_allowed: x64
+# Defaults to `x64compatible` if not specified.
+# architectures_allowed: x64compatible
 
 # Space-separated list of architectures that should enable 64-bit install mode.
-# Defaults to `x64` if not specified.
-# architectures_install_in_64bit_mode: x64
+# Defaults to `x64compatible` if not specified.
+# architectures_install_in_64bit_mode: x64compatible

--- a/examples/hello_world/windows/packaging/exe/make_config.yaml
+++ b/examples/hello_world/windows/packaging/exe/make_config.yaml
@@ -8,3 +8,10 @@ launch_at_startup: true
 # install_dir_name: "D:\\HELLO-WORLD"
 locales:
   - zh
+# Space-separated list of architecture identifiers the installer is allowed to run on.
+# Defaults to `x64` if not specified.
+# architectures_allowed: x64
+
+# Space-separated list of architectures that should enable 64-bit install mode.
+# Defaults to `x64` if not specified.
+# architectures_install_in_64bit_mode: x64

--- a/packages/flutter_app_packager/lib/src/makers/exe/inno_setup/inno_setup_script.dart
+++ b/packages/flutter_app_packager/lib/src/makers/exe/inno_setup/inno_setup_script.dart
@@ -53,8 +53,8 @@ SolidCompression=yes
 SetupIconFile={{SETUP_ICON_FILE}}
 WizardStyle=modern
 PrivilegesRequired={{PRIVILEGES_REQUIRED}}
-ArchitecturesAllowed=x64
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed={{ARCHITECTURES_ALLOWED}}
+ArchitecturesInstallIn64BitMode={{ARCHITECTURES_INSTALL_IN_64BIT_MODE}}
 
 [Languages]
 {% for locale in LOCALES %}
@@ -180,6 +180,9 @@ class InnoSetupScript {
       'LOCALES': _getAvailableLocales(),
       'SETUP_ICON_FILE': makeConfig.setupIconFile ?? '',
       'PRIVILEGES_REQUIRED': makeConfig.privilegesRequired ?? 'none',
+      'ARCHITECTURES_ALLOWED': makeConfig.architecturesAllowed ?? 'x64',
+      'ARCHITECTURES_INSTALL_IN_64BIT_MODE':
+          makeConfig.architecturesInstallIn64BitMode ?? 'x64',
     }..removeWhere((key, value) => value == null);
 
     Context context = Context.create();

--- a/packages/flutter_app_packager/lib/src/makers/exe/inno_setup/inno_setup_script.dart
+++ b/packages/flutter_app_packager/lib/src/makers/exe/inno_setup/inno_setup_script.dart
@@ -180,9 +180,9 @@ class InnoSetupScript {
       'LOCALES': _getAvailableLocales(),
       'SETUP_ICON_FILE': makeConfig.setupIconFile ?? '',
       'PRIVILEGES_REQUIRED': makeConfig.privilegesRequired ?? 'none',
-      'ARCHITECTURES_ALLOWED': makeConfig.architecturesAllowed ?? 'x64',
-      'ARCHITECTURES_INSTALL_IN_64BIT_MODE':
-          makeConfig.architecturesInstallIn64BitMode ?? 'x64',
+      'ARCHITECTURES_ALLOWED': makeConfig.architecturesAllowed ?? 'x64compatible',
+            'ARCHITECTURES_INSTALL_IN_64BIT_MODE':
+                makeConfig.architecturesInstallIn64BitMode ?? 'x64compatible',
     }..removeWhere((key, value) => value == null);
 
     Context context = Context.create();

--- a/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
@@ -68,13 +68,13 @@ class MakeExeConfig extends MakeConfig {
 
   /// Space-separated list of architecture identifiers (or a boolean expression)
   /// specifying which architectures Setup is allowed to run on.
-  /// Defaults to `x64`.
+  /// Defaults to `x64compatible`.
   /// See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed
   String? architecturesAllowed;
 
   /// Space-separated list of architecture identifiers (or a boolean expression)
   /// specifying which architectures should enable 64-bit install mode.
-  /// Defaults to `x64`.
+  /// Defaults to `x64compatible`.
   /// See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode
   String? architecturesInstallIn64BitMode;
 

--- a/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
@@ -66,12 +66,14 @@ class MakeExeConfig extends MakeConfig {
   String? privilegesRequired;
   List<String>? locales;
 
-  /// Comma-separated list of architectures the installer is allowed to run on.
+  /// Space-separated list of architecture identifiers (or a boolean expression)
+  /// specifying which architectures Setup is allowed to run on.
   /// Defaults to `x64`.
   /// See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed
   String? architecturesAllowed;
 
-  /// Comma-separated list of 64-bit architectures that trigger 64-bit install mode.
+  /// Space-separated list of architecture identifiers (or a boolean expression)
+  /// specifying which architectures should enable 64-bit install mode.
   /// Defaults to `x64`.
   /// See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode
   String? architecturesInstallIn64BitMode;

--- a/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
@@ -17,6 +17,8 @@ class MakeExeConfig extends MakeConfig {
     this.setupIconFile,
     this.privilegesRequired,
     this.locales,
+    this.architecturesAllowed,
+    this.architecturesInstallIn64BitMode,
   });
 
   factory MakeExeConfig.fromJson(Map<String, dynamic> json) {
@@ -44,6 +46,9 @@ class MakeExeConfig extends MakeConfig {
       setupIconFile: iconfile,
       privilegesRequired: json['privileges_required'],
       locales: locales,
+      architecturesAllowed: json['architectures_allowed'],
+      architecturesInstallIn64BitMode:
+          json['architectures_install_in_64bit_mode'],
     );
     return makeExeConfig;
   }
@@ -60,6 +65,16 @@ class MakeExeConfig extends MakeConfig {
   String? setupIconFile;
   String? privilegesRequired;
   List<String>? locales;
+
+  /// Comma-separated list of architectures the installer is allowed to run on.
+  /// Defaults to `x64`.
+  /// See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesallowed
+  String? architecturesAllowed;
+
+  /// Comma-separated list of 64-bit architectures that trigger 64-bit install mode.
+  /// Defaults to `x64`.
+  /// See: https://jrsoftware.org/ishelp/index.php?topic=setup_architecturesinstallin64bitmode
+  String? architecturesInstallIn64BitMode;
 
   String get defaultExecutableName {
     File executableFile = packagingDirectory
@@ -93,6 +108,8 @@ class MakeExeConfig extends MakeConfig {
       'setup_icon_file': setupIconFile,
       'privileges_required': privilegesRequired,
       'locales': locales,
+      'architectures_allowed': architecturesAllowed,
+      'architectures_install_in_64bit_mode': architecturesInstallIn64BitMode,
     }..removeWhere((key, value) => value == null);
   }
 }


### PR DESCRIPTION
## Summary

Closes #157

Adds `architectures_allowed` and `architectures_install_in_64bit_mode` configuration options to the EXE (Inno Setup) maker, replacing the previously hardcoded values.

## Changes

- **`make_exe_config.dart`**: Added `architecturesAllowed` and `architecturesInstallIn64BitMode` fields with JSON serialization/deserialization support and doc comments linking to Inno Setup documentation.
- **`inno_setup_script.dart`**: Replaced hardcoded `ArchitecturesAllowed=x64` and `ArchitecturesInstallIn64BitMode=x64` with template variables, defaulting to `x64` for backward compatibility.

## Usage

Users can now configure the target architectures in `windows/packaging/exe/make_config.yaml`:

```yaml
# Default (x64 only, can be omitted):
architectures_allowed: x64
architectures_install_in_64bit_mode: x64

# For x64 + arm64 support:
architectures_allowed: x64 arm64
architectures_install_in_64bit_mode: x64 arm64
```

If not configured, behavior is identical to before (hardcoded `x64`).