### PR TITLE
Allow inheritance of common configuration options thoughout the config

### DIFF
--- a/apps/docs/en/makers/appimage.md
+++ b/apps/docs/en/makers/appimage.md
@@ -29,6 +29,8 @@ Build your Flutter app as a Linux AppImage — a portable application format tha
 
 Add `make_config.yaml` to your project `linux/packaging/appimage` directory.
 
+You can also add `make_config.yaml` to your project `linux/packaging` directory to load default configuration.
+
 ```yaml
 display_name: Hello World
 

--- a/apps/docs/en/makers/appimage.md
+++ b/apps/docs/en/makers/appimage.md
@@ -29,7 +29,7 @@ Build your Flutter app as a Linux AppImage — a portable application format tha
 
 Add `make_config.yaml` to your project `linux/packaging/appimage` directory.
 
-You can also add `make_config.yaml` to your project `linux/packaging` directory to load default configuration.
+You can also add `make_config.yaml` to your project `linux/packaging` directory to inherit common configuration.
 
 ```yaml
 display_name: Hello World

--- a/apps/docs/en/makers/deb.md
+++ b/apps/docs/en/makers/deb.md
@@ -11,7 +11,7 @@ Build your Flutter app as a Debian package (`.deb`) for installation on Debian-b
 
 Add `make_config.yaml` to your project `linux/packaging/deb` directory.
 
-You can also add `make_config.yaml` to your project `linux/packaging` directory to load default configuration.
+You can also add `make_config.yaml` to your project `linux/packaging` directory to inherit common configuration.
 
 ```yaml
 display_name: Hello World

--- a/apps/docs/en/makers/deb.md
+++ b/apps/docs/en/makers/deb.md
@@ -11,6 +11,8 @@ Build your Flutter app as a Debian package (`.deb`) for installation on Debian-b
 
 Add `make_config.yaml` to your project `linux/packaging/deb` directory.
 
+You can also add `make_config.yaml` to your project `linux/packaging` directory to load default configuration.
+
 ```yaml
 display_name: Hello World
 package_name: hello-world

--- a/apps/docs/en/makers/dmg.md
+++ b/apps/docs/en/makers/dmg.md
@@ -19,6 +19,8 @@ Build your Flutter app as a macOS DMG (Apple Disk Image) package for distributio
 
 Add `make_config.yaml` to your project `macos/packaging/dmg` directory.
 
+You can also add `make_config.yaml` to your project `macos/packaging` directory to load default configuration.
+
 ```yaml
 title: hello_world
 contents:

--- a/apps/docs/en/makers/dmg.md
+++ b/apps/docs/en/makers/dmg.md
@@ -19,7 +19,7 @@ Build your Flutter app as a macOS DMG (Apple Disk Image) package for distributio
 
 Add `make_config.yaml` to your project `macos/packaging/dmg` directory.
 
-You can also add `make_config.yaml` to your project `macos/packaging` directory to load default configuration.
+You can also add `make_config.yaml` to your project `macos/packaging` directory to inherit common configuration.
 
 ```yaml
 title: hello_world

--- a/apps/docs/en/makers/exe.md
+++ b/apps/docs/en/makers/exe.md
@@ -11,6 +11,8 @@ Build your Flutter app as a Windows EXE installer using Inno Setup. This creates
 
 Add `make_config.yaml` to your project `windows/packaging/exe` directory.
 
+You can also add `make_config.yaml` to your project `windows/packaging` directory to load default configuration.
+
 ```yaml
 # The value of AppId uniquely identifies this application.
 # Do not use the same AppId value in installers for other applications.

--- a/apps/docs/en/makers/exe.md
+++ b/apps/docs/en/makers/exe.md
@@ -11,7 +11,7 @@ Build your Flutter app as a Windows EXE installer using Inno Setup. This creates
 
 Add `make_config.yaml` to your project `windows/packaging/exe` directory.
 
-You can also add `make_config.yaml` to your project `windows/packaging` directory to load default configuration.
+You can also add `make_config.yaml` to your project `windows/packaging` directory to inherit common configuration.
 
 ```yaml
 # The value of AppId uniquely identifies this application.

--- a/apps/docs/en/makers/msix.md
+++ b/apps/docs/en/makers/msix.md
@@ -11,7 +11,7 @@ Build your Flutter app as a Windows MSIX package. MSIX is Microsoft's modern app
 
 Add `make_config.yaml` to your project `windows/packaging/msix` directory.
 
-You can also add `make_config.yaml` to your project `windows/packaging` directory to load default configuration.
+You can also add `make_config.yaml` to your project `windows/packaging` directory to inherit common configuration.
 
 ```yaml
 display_name: HelloWorld

--- a/apps/docs/en/makers/msix.md
+++ b/apps/docs/en/makers/msix.md
@@ -11,6 +11,8 @@ Build your Flutter app as a Windows MSIX package. MSIX is Microsoft's modern app
 
 Add `make_config.yaml` to your project `windows/packaging/msix` directory.
 
+You can also add `make_config.yaml` to your project `windows/packaging` directory to load default configuration.
+
 ```yaml
 display_name: HelloWorld
 msix_version: 1.0.0.0

--- a/apps/docs/en/makers/pkg.md
+++ b/apps/docs/en/makers/pkg.md
@@ -8,7 +8,7 @@ Build your Flutter app as a macOS PKG installer package. The PKG format is Apple
 
 Add `make_config.yaml` to your project `macos/packaging/pkg` directory.
 
-You can also add `make_config.yaml` to your project `macos/packaging` directory to load default configuration.
+You can also add `make_config.yaml` to your project `macos/packaging` directory to inherit common configuration.
 
 ```yaml
 # Required: Installation path prefix for the app bundle.

--- a/apps/docs/en/makers/pkg.md
+++ b/apps/docs/en/makers/pkg.md
@@ -8,6 +8,8 @@ Build your Flutter app as a macOS PKG installer package. The PKG format is Apple
 
 Add `make_config.yaml` to your project `macos/packaging/pkg` directory.
 
+You can also add `make_config.yaml` to your project `macos/packaging` directory to load default configuration.
+
 ```yaml
 # Required: Installation path prefix for the app bundle.
 # The app will be installed as <install-path>/<AppName>.app.

--- a/apps/docs/en/makers/rpm.md
+++ b/apps/docs/en/makers/rpm.md
@@ -18,6 +18,8 @@ Install requirements:
 
 Add `make_config.yaml` to your project `linux/packaging/rpm` directory.
 
+You can also add `make_config.yaml` to your project `linux/packaging` directory to load default configuration.
+
 ```yaml
 icon: assets/logo.png
 summary: A really cool application

--- a/apps/docs/en/makers/rpm.md
+++ b/apps/docs/en/makers/rpm.md
@@ -18,7 +18,7 @@ Install requirements:
 
 Add `make_config.yaml` to your project `linux/packaging/rpm` directory.
 
-You can also add `make_config.yaml` to your project `linux/packaging` directory to load default configuration.
+You can also add `make_config.yaml` to your project `linux/packaging` directory to inherit common configuration.
 
 ```yaml
 icon: assets/logo.png

--- a/apps/docs/zh/makers/appimage.md
+++ b/apps/docs/zh/makers/appimage.md
@@ -29,6 +29,8 @@
 
 将 `make_config.yaml` 添加到您的项目 `linux/packaging/appimage` 目录。
 
+你也可以将 `make_config.yaml` 添加到你的项目 `linux/packaging` 目录，以加载默认配置。
+
 ```yaml
 display_name: Hello World
 

--- a/apps/docs/zh/makers/appimage.md
+++ b/apps/docs/zh/makers/appimage.md
@@ -29,7 +29,7 @@
 
 将 `make_config.yaml` 添加到您的项目 `linux/packaging/appimage` 目录。
 
-你也可以将 `make_config.yaml` 添加到你的项目 `linux/packaging` 目录，以加载默认配置。
+你也可以将 `make_config.yaml` 添加到你的项目 `linux/packaging` 目录，以继承公共配置。
 
 ```yaml
 display_name: Hello World

--- a/apps/docs/zh/makers/deb.md
+++ b/apps/docs/zh/makers/deb.md
@@ -11,6 +11,8 @@
 
 将 `make_config.yaml` 添加到您的项目 `linux/packaging/deb` 目录。
 
+你也可以将 `make_config.yaml` 添加到你的项目 `linux/packaging` 目录，以加载默认配置。
+
 ```yaml
 display_name: Hello World
 package_name: hello-world

--- a/apps/docs/zh/makers/deb.md
+++ b/apps/docs/zh/makers/deb.md
@@ -11,7 +11,7 @@
 
 将 `make_config.yaml` 添加到您的项目 `linux/packaging/deb` 目录。
 
-你也可以将 `make_config.yaml` 添加到你的项目 `linux/packaging` 目录，以加载默认配置。
+你也可以将 `make_config.yaml` 添加到你的项目 `linux/packaging` 目录，以继承公共配置。
 
 ```yaml
 display_name: Hello World

--- a/apps/docs/zh/makers/dmg.md
+++ b/apps/docs/zh/makers/dmg.md
@@ -19,7 +19,7 @@
 
 将 `make_config.yaml` 添加到你的项目 `macos/packaging/dmg` 目录。
 
-你也可以将 `make_config.yaml` 添加到你的项目 `macos/packaging` 目录，以加载默认配置。
+你也可以将 `make_config.yaml` 添加到你的项目 `macos/packaging` 目录，以继承公共配置。
 
 ```yaml
 title: hello_world

--- a/apps/docs/zh/makers/dmg.md
+++ b/apps/docs/zh/makers/dmg.md
@@ -19,6 +19,8 @@
 
 将 `make_config.yaml` 添加到你的项目 `macos/packaging/dmg` 目录。
 
+你也可以将 `make_config.yaml` 添加到你的项目 `macos/packaging` 目录，以加载默认配置。
+
 ```yaml
 title: hello_world
 contents:

--- a/apps/docs/zh/makers/exe.md
+++ b/apps/docs/zh/makers/exe.md
@@ -11,6 +11,8 @@
 
 将 `make_config.yaml` 添加到你的项目 `windows/packaging/exe` 目录。
 
+你也可以将 `make_config.yaml` 添加到你的项目 `windows/packaging` 目录，以加载默认配置。
+
 ```yaml
 # AppId 的值唯一标识此应用。
 # 不要在其他应用的安装程序中使用相同的 AppId 值。

--- a/apps/docs/zh/makers/exe.md
+++ b/apps/docs/zh/makers/exe.md
@@ -11,7 +11,7 @@
 
 将 `make_config.yaml` 添加到你的项目 `windows/packaging/exe` 目录。
 
-你也可以将 `make_config.yaml` 添加到你的项目 `windows/packaging` 目录，以加载默认配置。
+你也可以将 `make_config.yaml` 添加到你的项目 `windows/packaging` 目录，以继承公共配置。
 
 ```yaml
 # AppId 的值唯一标识此应用。

--- a/apps/docs/zh/makers/msix.md
+++ b/apps/docs/zh/makers/msix.md
@@ -11,7 +11,7 @@
 
 将 `make_config.yaml` 添加到你的项目 `windows/packaging/msix` 目录。
 
-你也可以将 `make_config.yaml` 添加到你的项目 `windows/packaging` 目录，以加载默认配置。
+你也可以将 `make_config.yaml` 添加到你的项目 `windows/packaging` 目录，以继承公共配置。
 
 ```yaml
 display_name: HelloWorld

--- a/apps/docs/zh/makers/msix.md
+++ b/apps/docs/zh/makers/msix.md
@@ -11,6 +11,8 @@
 
 将 `make_config.yaml` 添加到你的项目 `windows/packaging/msix` 目录。
 
+你也可以将 `make_config.yaml` 添加到你的项目 `windows/packaging` 目录，以加载默认配置。
+
 ```yaml
 display_name: HelloWorld
 msix_version: 1.0.0.0

--- a/apps/docs/zh/makers/pkg.md
+++ b/apps/docs/zh/makers/pkg.md
@@ -8,6 +8,8 @@
 
 将 `make_config.yaml` 添加到你的项目 `macos/packaging/pkg` 目录。
 
+你也可以将 `make_config.yaml` 添加到你的项目 `macos/packaging` 目录，以加载默认配置。
+
 ```yaml
 # 必填：应用程序的安装路径前缀。
 # 应用将被安装到 <install-path>/<AppName>.app。

--- a/apps/docs/zh/makers/pkg.md
+++ b/apps/docs/zh/makers/pkg.md
@@ -8,7 +8,7 @@
 
 将 `make_config.yaml` 添加到你的项目 `macos/packaging/pkg` 目录。
 
-你也可以将 `make_config.yaml` 添加到你的项目 `macos/packaging` 目录，以加载默认配置。
+你也可以将 `make_config.yaml` 添加到你的项目 `macos/packaging` 目录，以继承公共配置。
 
 ```yaml
 # 必填：应用程序的安装路径前缀。

--- a/apps/docs/zh/makers/rpm.md
+++ b/apps/docs/zh/makers/rpm.md
@@ -18,6 +18,8 @@
 
 将 `make_config.yaml` 添加到您的项目 `linux/packaging/rpm` 目录。
 
+你也可以将 `make_config.yaml` 添加到你的项目 `linux/packaging` 目录，以加载默认配置。
+
 ```yaml
 icon: assets/logo.png
 summary: A really cool application

--- a/apps/docs/zh/makers/rpm.md
+++ b/apps/docs/zh/makers/rpm.md
@@ -18,7 +18,7 @@
 
 将 `make_config.yaml` 添加到您的项目 `linux/packaging/rpm` 目录。
 
-你也可以将 `make_config.yaml` 添加到你的项目 `linux/packaging` 目录，以加载默认配置。
+你也可以将 `make_config.yaml` 添加到你的项目 `linux/packaging` 目录，以继承公共配置。
 
 ```yaml
 icon: assets/logo.png

--- a/examples/hello_world/linux/packaging/appimage/make_config.yaml
+++ b/examples/hello_world/linux/packaging/appimage/make_config.yaml
@@ -1,21 +1,3 @@
-display_name: Hello World
-
-icon: assets/logo.png
-
-keywords:
-  - Hello
-  - World
-  - Test
-  - Application
-
-generic_name: Cool Application
-
-# supported mime types that can be opened using this application
-# supported_mime_type:
-#   - audio/mpeg
-
-metainfo: linux/packaging/helloworld.appdata.xml
-
 actions:
   - name: Say Hi
     label: say-hi
@@ -27,11 +9,6 @@ actions:
     arguments:
       - --say
       - bye
-
-categories:
-  - Music
-
-startup_notify: true
 
 # You can specify the shared libraries that you want to bundle with your app
 #

--- a/examples/hello_world/linux/packaging/appimage/make_config.yaml
+++ b/examples/hello_world/linux/packaging/appimage/make_config.yaml
@@ -1,3 +1,7 @@
+# supported mime types that can be opened using this application
+# supported_mime_type:
+#   - audio/mpeg
+
 actions:
   - name: Say Hi
     label: say-hi

--- a/examples/hello_world/linux/packaging/deb/make_config.yaml
+++ b/examples/hello_world/linux/packaging/deb/make_config.yaml
@@ -1,7 +1,3 @@
-# the name used to display in the OS. Specifically desktop
-# entry name
-display_name: Hello World
-
 # package name for debian/apt repository
 # the name should be all lowercase with -+.
 package_name: hello-world
@@ -25,90 +21,9 @@ section: x11
 # the size of binary in kilobyte
 installed_size: 6604
 
-# direct dependencies required by the application
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# dependencies:
-#   - libkeybinder-3.0-0 (>= 0.3.2)
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# build_dependencies_indep:
-#   - texinfo
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# build_dependencies:
-#   - kernel-headers-2.2.10 [!hurd-i386]
-#   - gnumach-dev [hurd-i386]
-#   - libluajit5.1-dev [i386 amd64 kfreebsd-i386 armel armhf powerpc mips]
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# recommended_dependencies:
-#   - neofetch
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# suggested_dependencies:
-#   - libkeybinder-3.0-0 (>= 0.3.2)
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# enhances:
-#   - spotube
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# pre_dependencies:
-#   - libc6
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#packages-which-break-other-packages-breaks
-# breaks:
-#   - libspotify (<< 3.0.0)
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-binary-packages-conflicts
-# conflicts:
-#   - spotify
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#virtual-packages-provides
-# provides:
-#   - libx11
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-and-replacing-packages-replaces
-# replaces:
-#   - spotify
-
 essential: false
 
 postinstall_scripts:
   - echo `Installed my awesome app`
 postuninstall_scripts:
   - echo `Surprised Pickachu face`
-
-# application icon path relative to project url
-icon: assets/logo.png
-
-keywords:
-  - Hello
-  - World
-  - Test
-  - Application
-
-# a name to categorize the app into a section of application
-generic_name: Music Application
-
-# supported mime types that can be opened using this application
-# supported_mime_type:
-#   - audio/mpeg
-
-metainfo: linux/packaging/helloworld.appdata.xml
-
-# shown when right clicked the desktop entry icons
-# actions:
-#   - Gallery
-#   - Create
-
-# the categories the application belong to
-# refer: https://specifications.freedesktop.org/menu-spec/latest/
-categories:
-  - Music
-  - Media
-
-# let OS know if the application can be run on start_up. If it's false
-# the application will deny to the OS if it was added as a start_up
-# application
-startup_notify: true

--- a/examples/hello_world/linux/packaging/deb/make_config.yaml
+++ b/examples/hello_world/linux/packaging/deb/make_config.yaml
@@ -21,9 +21,65 @@ section: x11
 # the size of binary in kilobyte
 installed_size: 6604
 
+# direct dependencies required by the application
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# dependencies:
+#   - libkeybinder-3.0-0 (>= 0.3.2)
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# build_dependencies_indep:
+#   - texinfo
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# build_dependencies:
+#   - kernel-headers-2.2.10 [!hurd-i386]
+#   - gnumach-dev [hurd-i386]
+#   - libluajit5.1-dev [i386 amd64 kfreebsd-i386 armel armhf powerpc mips]
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# recommended_dependencies:
+#   - neofetch
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# suggested_dependencies:
+#   - libkeybinder-3.0-0 (>= 0.3.2)
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# enhances:
+#   - spotube
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# pre_dependencies:
+#   - libc6
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#packages-which-break-other-packages-breaks
+# breaks:
+#   - libspotify (<< 3.0.0)
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-binary-packages-conflicts
+# conflicts:
+#   - spotify
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#virtual-packages-provides
+# provides:
+#   - libx11
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-and-replacing-packages-replaces
+# replaces:
+#   - spotify
+
 essential: false
 
 postinstall_scripts:
   - echo `Installed my awesome app`
 postuninstall_scripts:
   - echo `Surprised Pickachu face`
+
+# supported mime types that can be opened using this application
+# supported_mime_type:
+#   - audio/mpeg
+
+# shown when right clicked the desktop entry icons
+# actions:
+#   - Gallery
+#   - Create

--- a/examples/hello_world/linux/packaging/deb/make_config.yaml
+++ b/examples/hello_world/linux/packaging/deb/make_config.yaml
@@ -75,6 +75,9 @@ postinstall_scripts:
 postuninstall_scripts:
   - echo `Surprised Pickachu face`
 
+# a name to categorize the app into a section of application (overrides common generic_name)
+generic_name: Music Application
+
 # supported mime types that can be opened using this application
 # supported_mime_type:
 #   - audio/mpeg

--- a/examples/hello_world/linux/packaging/make_config.yaml
+++ b/examples/hello_world/linux/packaging/make_config.yaml
@@ -1,0 +1,18 @@
+display_name: Hello World
+
+icon: assets/logo.png
+
+keywords:
+  - Hello
+  - World
+  - Test
+  - Application
+
+generic_name: Cool Application
+
+metainfo: linux/packaging/helloworld.appdata.xml
+
+categories:
+  - Music
+
+startup_notify: true

--- a/examples/hello_world/linux/packaging/make_config.yaml
+++ b/examples/hello_world/linux/packaging/make_config.yaml
@@ -1,5 +1,8 @@
+# the name used to display in the OS. Specifically desktop
+# entry name
 display_name: Hello World
 
+# application icon path relative to project url
 icon: assets/logo.png
 
 keywords:
@@ -8,11 +11,17 @@ keywords:
   - Test
   - Application
 
+# a name to categorize the app into a section of application
 generic_name: Cool Application
 
 metainfo: linux/packaging/helloworld.appdata.xml
 
+# the categories the application belong to
+# refer: https://specifications.freedesktop.org/menu-spec/latest/
 categories:
   - Music
 
+# let OS know if the application can be run on start_up. If it's false
+# the application will deny to the OS if it was added as a start_up
+# application
 startup_notify: true

--- a/examples/hello_world/linux/packaging/pacman/make_config.yaml
+++ b/examples/hello_world/linux/packaging/pacman/make_config.yaml
@@ -9,7 +9,63 @@ maintainer:
 # the size of binary in kilobyte
 installed_size: 6604
 
+# direct dependencies required by the application
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# dependencies:
+#   - libkeybinder-3.0-0 (>= 0.3.2)
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# build_dependencies_indep:
+#   - texinfo
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# build_dependencies:
+#   - kernel-headers-2.2.10 [!hurd-i386]
+#   - gnumach-dev [hurd-i386]
+#   - libluajit5.1-dev [i386 amd64 kfreebsd-i386 armel armhf powerpc mips]
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# recommended_dependencies:
+#   - neofetch
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# suggested_dependencies:
+#   - libkeybinder-3.0-0 (>= 0.3.2)
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# enhances:
+#   - spotube
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
+# pre_dependencies:
+#   - libc6
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#packages-which-break-other-packages-breaks
+# breaks:
+#   - libspotify (<< 3.0.0)
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-binary-packages-conflicts
+# conflicts:
+#   - spotify
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#virtual-packages-provides
+# provides:
+#   - libx11
+
+# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-and-replacing-packages-replaces
+# replaces:
+#   - spotify
+
 postinstall_scripts:
   - echo `Installed my awesome app`
 postuninstall_scripts:
   - echo `Surprised Pickachu face`
+
+# supported mime types that can be opened using this application
+# supported_mime_type:
+#   - audio/mpeg
+
+# shown when right clicked the desktop entry icons
+# actions:
+#   - Gallery
+#   - Create

--- a/examples/hello_world/linux/packaging/pacman/make_config.yaml
+++ b/examples/hello_world/linux/packaging/pacman/make_config.yaml
@@ -1,8 +1,4 @@
-# the name used to display in the OS. Specifically desktop
-# entry name
-display_name: Hello World
-
-# package name for debian/apt repository
+# package name for repository
 # the name should be all lowercase with -+.
 package_name: hello-world
 
@@ -13,88 +9,7 @@ maintainer:
 # the size of binary in kilobyte
 installed_size: 6604
 
-# direct dependencies required by the application
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# dependencies:
-#   - libkeybinder-3.0-0 (>= 0.3.2)
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# build_dependencies_indep:
-#   - texinfo
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# build_dependencies:
-#   - kernel-headers-2.2.10 [!hurd-i386]
-#   - gnumach-dev [hurd-i386]
-#   - libluajit5.1-dev [i386 amd64 kfreebsd-i386 armel armhf powerpc mips]
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# recommended_dependencies:
-#   - neofetch
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# suggested_dependencies:
-#   - libkeybinder-3.0-0 (>= 0.3.2)
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# enhances:
-#   - spotube
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html
-# pre_dependencies:
-#   - libc6
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#packages-which-break-other-packages-breaks
-# breaks:
-#   - libspotify (<< 3.0.0)
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-binary-packages-conflicts
-# conflicts:
-#   - spotify
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#virtual-packages-provides
-# provides:
-#   - libx11
-
-# refer: https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-and-replacing-packages-replaces
-# replaces:
-#   - spotify
-
 postinstall_scripts:
   - echo `Installed my awesome app`
 postuninstall_scripts:
   - echo `Surprised Pickachu face`
-
-# application icon path relative to project url
-icon: assets/logo.png
-
-keywords:
-  - Hello
-  - World
-  - Test
-  - Application
-
-# a name to categorize the app into a section of application
-generic_name: Music Application
-
-# supported mime types that can be opened using this application
-# supported_mime_type:
-#   - audio/mpeg
-
-metainfo: linux/packaging/helloworld.appdata.xml
-
-# shown when right clicked the desktop entry icons
-# actions:
-#   - Gallery
-#   - Create
-
-# the categories the application belong to
-# refer: https://specifications.freedesktop.org/menu-spec/latest/
-categories:
-  - Music
-  - Media
-
-# let OS know if the application can be run on start_up. If it's false
-# the application will deny to the OS if it was added as a start_up
-# application
-startup_notify: true

--- a/examples/hello_world/linux/packaging/pacman/make_config.yaml
+++ b/examples/hello_world/linux/packaging/pacman/make_config.yaml
@@ -61,6 +61,9 @@ postinstall_scripts:
 postuninstall_scripts:
   - echo `Surprised Pickachu face`
 
+# a name to categorize the app into a section of application (overrides common generic_name)
+generic_name: Music Application
+
 # supported mime types that can be opened using this application
 # supported_mime_type:
 #   - audio/mpeg

--- a/examples/hello_world/linux/packaging/rpm/make_config.yaml
+++ b/examples/hello_world/linux/packaging/rpm/make_config.yaml
@@ -1,4 +1,3 @@
-icon: assets/logo.png
 summary: A really cool application
 group: Application/Emulator
 vendor: Kingkor Roy Tirtho
@@ -6,21 +5,3 @@ packager: Kingkor Roy Tirtho
 packager_email: krtirtho@gmail.com
 license: GPLv3
 url: https://github.com/fastforgedev/fastforge
-
-display_name: Hello World
-
-keywords:
-  - Hello
-  - World
-  - Test
-  - Application
-
-generic_name: Cool Application
-
-metainfo: linux/packaging/helloworld.appdata.xml
-
-categories:
-  - Cool
-  - Awesome
-
-startup_notify: true

--- a/examples/hello_world/linux/packaging/rpm/make_config.yaml
+++ b/examples/hello_world/linux/packaging/rpm/make_config.yaml
@@ -5,3 +5,9 @@ packager: Kingkor Roy Tirtho
 packager_email: krtirtho@gmail.com
 license: GPLv3
 url: https://github.com/fastforgedev/fastforge
+
+# Demonstrates overriding inherited categories from parent make_config.yaml
+# refer: https://specifications.freedesktop.org/menu-spec/latest/
+categories:
+  - Cool
+  - Awesome

--- a/packages/flutter_app_packager/lib/src/api/app_package_maker.dart
+++ b/packages/flutter_app_packager/lib/src/api/app_package_maker.dart
@@ -55,6 +55,10 @@ Map<String, dynamic> loadMakeConfigYaml(String path) {
           'Default config file is not a valid YAML map.',
         );
       }
+    } else {
+      throw const FormatException(
+        'Default config file is not a valid YAML map.',
+      );
     }
   }
 
@@ -69,6 +73,10 @@ Map<String, dynamic> loadMakeConfigYaml(String path) {
           'Specific config file is not a valid YAML map.',
         );
       }
+    } else {
+      throw const FormatException(
+        'Specific config file is not a valid YAML map.',
+      );
     }
   }
 

--- a/packages/flutter_app_packager/lib/src/api/app_package_maker.dart
+++ b/packages/flutter_app_packager/lib/src/api/app_package_maker.dart
@@ -38,8 +38,10 @@ Map<String, dynamic> loadMakeConfigYaml(String path) {
   bool fileExists = file.existsSync();
 
   if (!defaultExists && !fileExists) {
-    final yamlDoc = loadYaml(file.readAsStringSync());
-    return json.decode(json.encode(yamlDoc)) as Map<String, dynamic>;
+    throw FileSystemException(
+      'Neither the specific config file nor the default config file exists.',
+      path,
+    );
   }
 
   if (defaultExists) {
@@ -48,6 +50,10 @@ Map<String, dynamic> loadMakeConfigYaml(String path) {
       final decoded = json.decode(json.encode(yamlDoc));
       if (decoded is Map<String, dynamic>) {
         config = _deepMerge(config, decoded);
+      } else {
+        throw const FormatException(
+          'Default config file is not a valid YAML map.',
+        );
       }
     }
   }
@@ -58,6 +64,10 @@ Map<String, dynamic> loadMakeConfigYaml(String path) {
       final decoded = json.decode(json.encode(yamlDoc));
       if (decoded is Map<String, dynamic>) {
         config = _deepMerge(config, decoded);
+      } else {
+        throw const FormatException(
+          'Specific config file is not a valid YAML map.',
+        );
       }
     }
   }

--- a/packages/flutter_app_packager/lib/src/api/app_package_maker.dart
+++ b/packages/flutter_app_packager/lib/src/api/app_package_maker.dart
@@ -10,9 +10,59 @@ export 'make_config.dart';
 export 'make_error.dart';
 export 'make_result.dart';
 
+Map<String, dynamic> _deepMerge(
+  Map<String, dynamic> target,
+  Map<String, dynamic> source,
+) {
+  for (final key in source.keys) {
+    final value = source[key];
+    if (value is Map<String, dynamic> &&
+        target.containsKey(key) &&
+        target[key] is Map<String, dynamic>) {
+      target[key] = _deepMerge(target[key] as Map<String, dynamic>, value);
+    } else {
+      target[key] = value;
+    }
+  }
+  return target;
+}
+
 Map<String, dynamic> loadMakeConfigYaml(String path) {
-  final yamlDoc = loadYaml(File(path).readAsStringSync());
-  return json.decode(json.encode(yamlDoc));
+  Map<String, dynamic> config = {};
+
+  final file = File(path);
+  final parentDir = file.parent.parent;
+  final defaultFile = File('${parentDir.path}/make_config.yaml');
+
+  bool defaultExists = defaultFile.existsSync();
+  bool fileExists = file.existsSync();
+
+  if (!defaultExists && !fileExists) {
+    final yamlDoc = loadYaml(file.readAsStringSync());
+    return json.decode(json.encode(yamlDoc)) as Map<String, dynamic>;
+  }
+
+  if (defaultExists) {
+    final yamlDoc = loadYaml(defaultFile.readAsStringSync());
+    if (yamlDoc != null) {
+      final decoded = json.decode(json.encode(yamlDoc));
+      if (decoded is Map<String, dynamic>) {
+        config = _deepMerge(config, decoded);
+      }
+    }
+  }
+
+  if (fileExists) {
+    final yamlDoc = loadYaml(file.readAsStringSync());
+    if (yamlDoc != null) {
+      final decoded = json.decode(json.encode(yamlDoc));
+      if (decoded is Map<String, dynamic>) {
+        config = _deepMerge(config, decoded);
+      }
+    }
+  }
+
+  return config;
 }
 
 abstract class AppPackageMaker {

--- a/packages/flutter_app_packager/test/src/api/make_config_test.dart
+++ b/packages/flutter_app_packager/test/src/api/make_config_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter_app_packager/src/api/make_config.dart';
+import 'package:flutter_app_packager/src/api/app_package_maker.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:test/test.dart';
@@ -40,6 +40,67 @@ void main() {
         makeConfig.outputArtifactPath,
         'dist/1.0.0+1/test_app-1.0.0+1-android.apk',
       );
+    });
+  });
+
+  group('loadMakeConfigYaml', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('fastforge_test_');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('should merge default config with specific config', () {
+      final platformDir = Directory('${tempDir.path}/linux/packaging');
+      final formatDir = Directory('${platformDir.path}/deb');
+      formatDir.createSync(recursive: true);
+
+      final defaultConfig = File('${platformDir.path}/make_config.yaml');
+      defaultConfig.writeAsStringSync('a: 1\nb:\n  c: 2\n  d: 3\n');
+
+      final specificConfig = File('${formatDir.path}/make_config.yaml');
+      specificConfig.writeAsStringSync('b:\n  d: 4\n  e: 5\nf: 6\n');
+
+      final result = loadMakeConfigYaml(specificConfig.path);
+
+      expect(result['a'], 1);
+      expect(result['b']['c'], 2);
+      expect(result['b']['d'], 4);
+      expect(result['b']['e'], 5);
+      expect(result['f'], 6);
+    });
+
+    test('should load specific config if default is missing', () {
+      final platformDir = Directory('${tempDir.path}/linux/packaging');
+      final formatDir = Directory('${platformDir.path}/deb');
+      formatDir.createSync(recursive: true);
+
+      final specificConfig = File('${formatDir.path}/make_config.yaml');
+      specificConfig.writeAsStringSync('a: 1\n');
+
+      final result = loadMakeConfigYaml(specificConfig.path);
+
+      expect(result['a'], 1);
+    });
+
+    test('should load default config if specific is missing', () {
+      final platformDir = Directory('${tempDir.path}/linux/packaging');
+      final formatDir = Directory('${platformDir.path}/deb');
+      formatDir.createSync(recursive: true);
+
+      final defaultConfig = File('${platformDir.path}/make_config.yaml');
+      defaultConfig.writeAsStringSync('a: 1\n');
+
+      final specificConfig = File('${formatDir.path}/make_config.yaml');
+      final result = loadMakeConfigYaml(specificConfig.path);
+
+      expect(result['a'], 1);
     });
   });
 }

--- a/packages/flutter_app_packager/test/src/api/make_config_test.dart
+++ b/packages/flutter_app_packager/test/src/api/make_config_test.dart
@@ -102,5 +102,51 @@ void main() {
 
       expect(result['a'], 1);
     });
+
+    test('should throw FileSystemException if neither config exists', () {
+      final platformDir = Directory('${tempDir.path}/linux/packaging');
+      final formatDir = Directory('${platformDir.path}/deb');
+      formatDir.createSync(recursive: true);
+
+      final specificConfig = File('${formatDir.path}/make_config.yaml');
+
+      expect(
+        () => loadMakeConfigYaml(specificConfig.path),
+        throwsA(isA<FileSystemException>()),
+      );
+    });
+
+    test('should throw FormatException if default config is invalid', () {
+      final platformDir = Directory('${tempDir.path}/linux/packaging');
+      final formatDir = Directory('${platformDir.path}/deb');
+      formatDir.createSync(recursive: true);
+
+      final defaultConfig = File('${platformDir.path}/make_config.yaml');
+      defaultConfig.writeAsStringSync('- a\n- b\n');
+
+      final specificConfig = File('${formatDir.path}/make_config.yaml');
+
+      expect(
+        () => loadMakeConfigYaml(specificConfig.path),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('should throw FormatException if specific config is invalid', () {
+      final platformDir = Directory('${tempDir.path}/linux/packaging');
+      final formatDir = Directory('${platformDir.path}/deb');
+      formatDir.createSync(recursive: true);
+
+      final defaultConfig = File('${platformDir.path}/make_config.yaml');
+      defaultConfig.writeAsStringSync('a: 1\n');
+
+      final specificConfig = File('${formatDir.path}/make_config.yaml');
+      specificConfig.writeAsStringSync('- a\n- b\n');
+
+      expect(
+        () => loadMakeConfigYaml(specificConfig.path),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
This creates a common "make_config.yaml" where the user can put common options so that they don't have to constantly re-specify. 