### PR TITLE
feat(appimage): add optional StartupWMClass support

### DIFF
--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -10,6 +10,12 @@ license.workspace = true
 name = "fastforge"
 path = "src/main.rs"
 
+# Compatibility alias: flutter_distributor was renamed to fastforge.
+# Same binary; shows a rename notice when invoked under the old name.
+[[bin]]
+name = "flutter_distributor"
+path = "src/main.rs"
+
 [dependencies]
 fastforge_core = { path = "../../crates/core" }
 fastforge_app_analyzer = { path = "../../crates/app_analyzer" }

--- a/apps/cli/src/cli/commands/package.rs
+++ b/apps/cli/src/cli/commands/package.rs
@@ -4,8 +4,11 @@ use fastforge_app_builder::{
     FlutterAppBuilder, GradleAppBuilder, IOSXcodeAppBuilder, MacOSXcodeAppBuilder, Platform,
 };
 use fastforge_app_packager::{
-    AndroidAabPackager, AndroidApkPackager, AppPackager, IOSIpaPackager, MacOSDmgPackager,
-    MacOSPkgPackager, MacOSZipPackager, PackageConfig,
+    AndroidAabPackager, AndroidApkPackager, AppPackager, CustomPackager, IOSIpaPackager,
+    LinuxAppImagePackager, LinuxDebPackager, LinuxDirectPackager, LinuxPacmanPackager,
+    LinuxRpmPackager, LinuxZipPackager, MacOSDmgPackager, MacOSPkgPackager, MacOSZipPackager,
+    OHOSAppPackager, OHOSHapPackager, PackageConfig, WebDirectPackager, WebZipPackager,
+    WindowsDirectPackager, WindowsExePackager, WindowsMsixPackager, WindowsZipPackager,
 };
 use serde::Deserialize;
 use serde_json::{Map, Value};
@@ -19,12 +22,38 @@ use std::str::FromStr;
 pub struct PackageArgs {
     #[arg(short, long = "platform")]
     pub platform: Option<String>,
-    #[arg(short, long = "target")]
-    pub target: Option<String>,
+    /// Comma-separated list of bundle types to build (e.g. `apk`, `dmg,zip`).
+    #[arg(short, long = "targets", alias = "target", value_name = "TARGET,...")]
+    pub targets: Option<String>,
+    /// Release channel included in the artifact name.
+    #[arg(long = "channel")]
+    pub channel: Option<String>,
+    /// Artifact name template (mustache syntax, e.g. `{{name}}-{{build_name}}.{{ext}}`).
+    #[arg(long = "artifact-name")]
+    pub artifact_name: Option<String>,
     #[arg(long = "skip-clean", default_value_t = false)]
     pub skip_clean: bool,
+
+    /// Comma-separated arguments passed directly to `flutter build`
+    /// (e.g. `verbose,obfuscate` or `split-debug-info=./symbols`).
+    #[arg(long = "flutter-build-args", value_name = "ARG,...")]
+    pub flutter_build_args: Option<String>,
+    /// The --target argument passed to `flutter build`.
     #[arg(long = "build-target")]
     pub build_target: Option<String>,
+    /// The --flavor argument passed to `flutter build`.
+    #[arg(long = "build-flavor")]
+    pub build_flavor: Option<String>,
+    /// The --target-platform argument passed to `flutter build`.
+    #[arg(long = "build-target-platform")]
+    pub build_target_platform: Option<String>,
+    /// The --export-options-plist argument passed to `flutter build`.
+    #[arg(long = "build-export-options-plist")]
+    pub build_export_options_plist: Option<String>,
+    /// The --dart-define argument(s) passed to `flutter build`.
+    /// May be repeated: `--build-dart-define foo=bar --build-dart-define a=b`.
+    #[arg(long = "build-dart-define", value_name = "KEY=VALUE")]
+    pub build_dart_define: Vec<String>,
 
     /// Shell command to run before packaging.
     #[arg(long = "hook-pre")]
@@ -35,20 +64,74 @@ pub struct PackageArgs {
     pub hook_post: Option<String>,
 }
 
+impl PackageArgs {
+    /// Builds the `flutter build` argument map, mirroring Dart's
+    /// `CommandPackage._generateBuildArgs`.
+    fn build_arguments(&self) -> Map<String, Value> {
+        let mut build_args = Map::new();
+        if let Some(value) = &self.build_target {
+            build_args.insert("target".to_string(), Value::String(value.clone()));
+        }
+        if let Some(value) = &self.build_flavor {
+            build_args.insert("flavor".to_string(), Value::String(value.clone()));
+        }
+        if let Some(value) = &self.build_target_platform {
+            build_args.insert("target-platform".to_string(), Value::String(value.clone()));
+        }
+        if let Some(value) = &self.build_export_options_plist {
+            build_args.insert(
+                "export-options-plist".to_string(),
+                Value::String(value.clone()),
+            );
+        }
+        if !self.build_dart_define.is_empty() {
+            let mut defines = Map::new();
+            for item in &self.build_dart_define {
+                if let Some((key, value)) = item.split_once('=') {
+                    defines.insert(key.to_string(), Value::String(value.to_string()));
+                }
+            }
+            build_args.insert("dart-define".to_string(), Value::Object(defines));
+        }
+        for arg in self
+            .flutter_build_args
+            .as_deref()
+            .unwrap_or("")
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            match arg.split_once('=') {
+                Some((key, value)) => {
+                    build_args
+                        .entry(key.to_string())
+                        .or_insert(Value::String(value.to_string()));
+                }
+                None => {
+                    build_args.entry(arg.to_string()).or_insert(Value::Bool(true));
+                }
+            }
+        }
+        build_args
+    }
+}
+
 pub async fn execute(args: &PackageArgs) -> Result<()> {
     log::info!("Executing package command");
     let platform = args
         .platform
         .as_deref()
         .ok_or_else(|| anyhow!("The 'platform' option is mandatory!"))?;
-    let target = args
-        .target
+    let targets: Vec<&str> = args
+        .targets
         .as_deref()
-        .ok_or_else(|| anyhow!("The 'target' option is mandatory!"))?;
-
-    let mut build_args = Map::new();
-    if let Some(value) = &args.build_target {
-        build_args.insert("target".to_string(), Value::String(value.clone()));
+        .unwrap_or("")
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if targets.is_empty() {
+        return Err(anyhow!("At least one 'target' must be specified!"));
     }
 
     // Build hooks map from CLI args
@@ -64,49 +147,104 @@ pub async fn execute(args: &PackageArgs) -> Result<()> {
     };
 
     let is_native = !is_flutter_project();
+    let mut clean_before_build = !args.skip_clean;
+    let mut artifacts = Vec::new();
 
-    let artifacts = if is_native && platform == "macos" {
-        log::info!("Detected native macOS Xcode project (no pubspec.yaml)");
-        package_native_macos_artifact(
-            target,
-            build_args,
-            std::env::vars().collect(),
-            "dist/",
-            None,
-            hooks.as_ref(),
-        )?
-    } else if is_native && platform == "ios" {
-        log::info!("Detected native iOS Xcode project (no pubspec.yaml)");
-        package_native_ios_artifact(
-            target,
-            build_args,
-            std::env::vars().collect(),
-            "dist/",
-            None,
-            hooks.as_ref(),
-        )?
-    } else if is_native && platform == "android" {
-        log::info!("Detected native Android project (no pubspec.yaml)");
-        package_native_android_artifact(
-            target,
-            build_args,
-            std::env::vars().collect(),
-            "dist/",
-            None,
-            hooks.as_ref(),
-        )?
-    } else {
-        package_flutter_artifact(
-            platform,
-            target,
-            build_args,
-            std::env::vars().collect(),
-            "dist/",
-            None,
-            !args.skip_clean,
-            hooks.as_ref(),
-        )?
-    };
+    // Non-android flutter platforms build once and reuse the output for
+    // subsequent targets (mirrors Dart's `isBuildOnlyOnce`); android rebuilds
+    // per target because apk/aab need different `flutter build` subcommands.
+    let mut cached_build: Option<fastforge_app_builder::BuildResult> = None;
+
+    for target in targets {
+        let build_args = args.build_arguments();
+        let target_artifacts = if is_native && platform == "macos" {
+            log::info!("Detected native macOS Xcode project (no pubspec.yaml)");
+            package_native_macos_artifact(
+                target,
+                build_args,
+                std::env::vars().collect(),
+                "dist/",
+                args.artifact_name.clone(),
+                hooks.as_ref(),
+            )?
+        } else if is_native && platform == "ios" {
+            log::info!("Detected native iOS Xcode project (no pubspec.yaml)");
+            package_native_ios_artifact(
+                target,
+                build_args,
+                std::env::vars().collect(),
+                "dist/",
+                args.artifact_name.clone(),
+                hooks.as_ref(),
+            )?
+        } else if is_native && platform == "android" {
+            log::info!("Detected native Android project (no pubspec.yaml)");
+            package_native_android_artifact(
+                target,
+                build_args,
+                std::env::vars().collect(),
+                "dist/",
+                args.artifact_name.clone(),
+                hooks.as_ref(),
+            )?
+        } else {
+            let flutter_platform = Platform::from_str(platform)
+                .map_err(|e| anyhow!("Invalid platform '{}': {}", platform, e))?;
+
+            // Fail fast on unsupported (platform, target) pairs before building.
+            let packager = resolve_packager(flutter_platform, target)?;
+            if !packager.is_supported_on_current_platform() {
+                return Err(anyhow!(
+                    "Packager '{}' is not supported on the current platform",
+                    target
+                ));
+            }
+            drop(packager);
+
+            let environment: HashMap<String, String> = std::env::vars().collect();
+            let build = match (&cached_build, flutter_platform) {
+                (Some(build), p) if p != Platform::Android => build,
+                _ => {
+                    let build = build_flutter_target(
+                        &flutter_platform,
+                        target,
+                        build_args,
+                        &environment,
+                        clean_before_build,
+                    )?;
+                    cached_build = Some(build);
+                    cached_build.as_ref().unwrap()
+                }
+            };
+
+            package_flutter_build(
+                &flutter_platform,
+                target,
+                build,
+                environment,
+                "dist/",
+                args.artifact_name.clone(),
+                args.channel.clone(),
+                hooks.as_ref(),
+            )?
+        };
+        // Clean at most once per invocation (mirrors Dart).
+        clean_before_build = false;
+
+        // Print a JSON summary per packaged target (mirrors Dart's
+        // MakeResult JSON output).
+        let summary = serde_json::json!({
+            "platform": platform,
+            "target": target,
+            "artifacts": target_artifacts
+                .iter()
+                .map(|p| p.to_string_lossy())
+                .collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&summary)?);
+
+        artifacts.extend(target_artifacts);
+    }
 
     for artifact in artifacts {
         println!("{}", artifact.display());
@@ -122,53 +260,106 @@ pub fn package_flutter_artifact(
     environment: HashMap<String, String>,
     output: &str,
     artifact_name: Option<String>,
+    channel: Option<String>,
     clean_before_build: bool,
     hooks: Option<&HashMap<String, serde_yaml::Value>>,
 ) -> Result<Vec<PathBuf>> {
     let platform = Platform::from_str(platform_str)
         .map_err(|e| anyhow!("Invalid platform '{}': {}", platform_str, e))?;
 
-    let builder = FlutterAppBuilder::default();
-    if clean_before_build {
-        builder
-            .clean(Some(&environment))
-            .map_err(|e| anyhow!("{}", e))?;
-    }
-
-    // Clone environment before it's moved into build()
-    let hook_env_base = environment.clone();
-
-    let build = builder
-        .build(&platform, Some(target), build_args, Some(environment))
-        .map_err(|e| anyhow!("{}", e))?;
-
-    let pubspec = ProjectPubspec::load()?;
-    let package_config = PackageConfig {
-        app_name: pubspec.name.clone(),
-        app_binary_name: pubspec.name,
-        app_version: pubspec.version,
-        build_mode: build.config.mode().as_str().to_string(),
-        platform,
-        flavor: build.config.flavor().map(ToOwned::to_owned),
-        channel: None,
-        artifact_name,
-        package_format: target.to_string(),
-        is_installer: matches!(
-            target,
-            "pkg" | "dmg" | "deb" | "rpm" | "pacman" | "exe" | "msix"
-        ),
-        build_output_dir: build.output_directory,
-        build_output_files: build.output_files,
-        output_dir: PathBuf::from(output),
-    };
-
-    let packager = macos_packager(target)?;
+    // Resolve the packager up-front so unsupported (platform, target) pairs
+    // fail fast, before any expensive build step runs.
+    let packager = resolve_packager(platform, target)?;
     if !packager.is_supported_on_current_platform() {
         return Err(anyhow!(
             "Packager '{}' is not supported on the current platform",
             target
         ));
     }
+    drop(packager);
+
+    let build = build_flutter_target(&platform, target, build_args, &environment, clean_before_build)?;
+    package_flutter_build(
+        &platform,
+        target,
+        &build,
+        environment,
+        output,
+        artifact_name,
+        channel,
+        hooks,
+    )
+}
+
+/// Runs `flutter build` for a `(platform, target)` pair, optionally cleaning
+/// first. Split from packaging so multi-target invocations can build once and
+/// reuse the output (mirrors Dart's `isBuildOnlyOnce` behavior).
+pub fn build_flutter_target(
+    platform: &Platform,
+    target: &str,
+    build_args: Map<String, Value>,
+    environment: &HashMap<String, String>,
+    clean_before_build: bool,
+) -> Result<fastforge_app_builder::BuildResult> {
+    let builder = FlutterAppBuilder::default();
+    if clean_before_build {
+        builder
+            .clean(Some(environment))
+            .map_err(|e| anyhow!("{}", e))?;
+    }
+    builder
+        .build(platform, Some(target), build_args, Some(environment.clone()))
+        .map_err(|e| anyhow!("{}", e))
+}
+
+/// Packages an existing flutter build output as `target`.
+#[allow(clippy::too_many_arguments)]
+pub fn package_flutter_build(
+    platform: &Platform,
+    target: &str,
+    build: &fastforge_app_builder::BuildResult,
+    environment: HashMap<String, String>,
+    output: &str,
+    artifact_name: Option<String>,
+    channel: Option<String>,
+    hooks: Option<&HashMap<String, serde_yaml::Value>>,
+) -> Result<Vec<PathBuf>> {
+    let platform = *platform;
+    let packager = resolve_packager(platform, target)?;
+    if !packager.is_supported_on_current_platform() {
+        return Err(anyhow!(
+            "Packager '{}' is not supported on the current platform",
+            target
+        ));
+    }
+
+    let hook_env_base = environment;
+
+    let pubspec = ProjectPubspec::load()?;
+    let app_binary_name = if platform == Platform::Linux {
+        linux_binary_name().unwrap_or_else(|| pubspec.name.clone())
+    } else {
+        pubspec.name.clone()
+    };
+    let package_config = PackageConfig {
+        app_name: pubspec.name.clone(),
+        app_binary_name,
+        app_version: pubspec.version,
+        build_mode: build.config.mode().as_str().to_string(),
+        platform,
+        flavor: build.config.flavor().map(ToOwned::to_owned),
+        channel,
+        artifact_name,
+        package_format: if target == "direct" {
+            String::new()
+        } else {
+            target.to_string()
+        },
+        is_installer: is_installer_target(target),
+        build_output_dir: build.output_directory.clone(),
+        build_output_files: build.output_files.clone(),
+        output_dir: PathBuf::from(output),
+    };
 
     // Resolve hooks: YAML allows both a single string and a list of strings
     let pre_hooks = resolve_hooks(hooks, "pre");
@@ -264,18 +455,70 @@ fn run_hooks(hooks: &[String], env: &HashMap<String, String>) -> Result<()> {
     Ok(())
 }
 
-fn macos_packager(target: &str) -> Result<Box<dyn AppPackager + Send + Sync>> {
-    match target {
-        "pkg" => Ok(Box::new(MacOSPkgPackager::from_yaml_file(
+/// Resolves the packager for a `(platform, target)` pair, covering the same
+/// matrix as Dart's `FlutterAppPackager` maker registry.
+pub fn resolve_packager(
+    platform: Platform,
+    target: &str,
+) -> Result<Box<dyn AppPackager + Send + Sync>> {
+    if target == "custom" {
+        return Ok(Box::new(CustomPackager::load(platform)?));
+    }
+    match (platform, target) {
+        (Platform::Android, "aab") => Ok(Box::new(AndroidAabPackager)),
+        (Platform::Android, "apk") => Ok(Box::new(AndroidApkPackager)),
+        (Platform::IOS, "ipa") => Ok(Box::new(IOSIpaPackager)),
+        (Platform::Linux, "appimage") => Ok(Box::new(LinuxAppImagePackager)),
+        (Platform::Linux, "deb") => Ok(Box::new(LinuxDebPackager)),
+        (Platform::Linux, "pacman") => Ok(Box::new(LinuxPacmanPackager)),
+        (Platform::Linux, "rpm") => Ok(Box::new(LinuxRpmPackager)),
+        (Platform::Linux, "zip") => Ok(Box::new(LinuxZipPackager)),
+        (Platform::Linux, "direct") => Ok(Box::new(LinuxDirectPackager)),
+        (Platform::MacOS, "pkg") => Ok(Box::new(MacOSPkgPackager::from_yaml_file(
             std::path::Path::new("macos/packaging/pkg/make_config.yaml"),
         )?)),
-        "dmg" => Ok(Box::new(MacOSDmgPackager)),
-        "zip" => Ok(Box::new(MacOSZipPackager)),
-        other => Err(anyhow!(
-            "Unsupported package target: `{}`. Currently supported for CLI packaging: pkg, dmg, zip",
-            other
+        (Platform::MacOS, "dmg") => Ok(Box::new(MacOSDmgPackager)),
+        (Platform::MacOS, "zip") => Ok(Box::new(MacOSZipPackager)),
+        (Platform::Ohos, "app") => Ok(Box::new(OHOSAppPackager)),
+        (Platform::Ohos, "hap") => Ok(Box::new(OHOSHapPackager)),
+        (Platform::Web, "zip") => Ok(Box::new(WebZipPackager)),
+        (Platform::Web, "direct") => Ok(Box::new(WebDirectPackager)),
+        (Platform::Windows, "exe") => Ok(Box::new(WindowsExePackager)),
+        (Platform::Windows, "msix") => Ok(Box::new(WindowsMsixPackager::default())),
+        (Platform::Windows, "zip") => Ok(Box::new(WindowsZipPackager)),
+        (Platform::Windows, "direct") => Ok(Box::new(WindowsDirectPackager)),
+        (platform, other) => Err(anyhow!(
+            "Unsupported package target `{}` for platform `{}`.",
+            other,
+            platform.as_str(),
         )),
     }
+}
+
+/// Whether packaging as `target` produces an installer artifact.
+/// Mirrors Dart, where only the `exe` maker sets `isInstaller = true`
+/// (reflected in the `-setup` suffix of the default artifact name).
+fn is_installer_target(target: &str) -> bool {
+    target == "exe"
+}
+
+/// Reads `BINARY_NAME` from `linux/CMakeLists.txt`, mirroring Dart's
+/// `MakeLinuxPackageConfig.appBinaryName`.
+fn linux_binary_name() -> Option<String> {
+    let content = std::fs::read_to_string("linux/CMakeLists.txt").ok()?;
+    let start = content.find("set(BINARY_NAME \"")? + "set(BINARY_NAME \"".len();
+    let rest = &content[start..];
+    let end = rest.find('"')?;
+    let name = &rest[..end];
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+fn macos_packager(target: &str) -> Result<Box<dyn AppPackager + Send + Sync>> {
+    resolve_packager(Platform::MacOS, target)
 }
 
 fn ios_packager(target: &str) -> Result<Box<dyn AppPackager + Send + Sync>> {
@@ -347,7 +590,7 @@ pub fn package_native_macos_artifact(
         channel: None,
         artifact_name,
         package_format: target.to_string(),
-        is_installer: matches!(target, "pkg" | "dmg"),
+        is_installer: is_installer_target(target),
         build_output_dir: build.output_directory,
         build_output_files: build.output_files,
         output_dir: PathBuf::from(output),
@@ -822,4 +1065,60 @@ impl ProjectPubspec {
 
 fn default_version() -> String {
     "0.1.0+1".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The full (platform, target) matrix registered by Dart's
+    /// `FlutterAppPackager` (minus `custom`, which needs a config file).
+    #[test]
+    fn resolve_packager_covers_dart_maker_matrix() {
+        let matrix: &[(&str, &[&str])] = &[
+            ("android", &["aab", "apk"]),
+            ("ios", &["ipa"]),
+            ("linux", &["appimage", "deb", "pacman", "rpm", "zip", "direct"]),
+            ("macos", &["dmg", "pkg", "zip"]),
+            ("ohos", &["app", "hap"]),
+            ("web", &["zip", "direct"]),
+            ("windows", &["exe", "msix", "zip", "direct"]),
+        ];
+        for (platform_str, targets) in matrix {
+            let platform = Platform::from_str(platform_str).unwrap();
+            for target in *targets {
+                let packager = resolve_packager(platform, target).unwrap_or_else(|e| {
+                    panic!("resolve_packager({platform_str}, {target}) failed: {e}")
+                });
+                assert_eq!(packager.name(), *target);
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_packager_rejects_mismatched_pairs() {
+        for (platform_str, target) in [
+            ("macos", "apk"),
+            ("android", "dmg"),
+            ("linux", "msix"),
+            ("web", "deb"),
+        ] {
+            let platform = Platform::from_str(platform_str).unwrap();
+            match resolve_packager(platform, target) {
+                Ok(_) => panic!("({platform_str}, {target}) must be rejected"),
+                Err(err) => assert!(
+                    err.to_string().contains("Unsupported package target"),
+                    "unexpected error for ({platform_str}, {target}): {err}"
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn only_exe_is_an_installer_target() {
+        assert!(is_installer_target("exe"));
+        for target in ["dmg", "pkg", "deb", "rpm", "pacman", "msix", "apk", "zip"] {
+            assert!(!is_installer_target(target), "{target} must not be an installer");
+        }
+    }
 }

--- a/apps/cli/src/cli/commands/publish.rs
+++ b/apps/cli/src/cli/commands/publish.rs
@@ -3,16 +3,23 @@ use clap::Args;
 use fastforge_app_publisher::{
     AppGalleryPublisher, AppPublisher, AppStorePublisher, CosPublisher, CustomPublisher,
     FirPublisher, FirebaseHostingPublisher, FirebasePublisher, GitHubPublisher, OssPublisher,
-    PublishConfig, QiniuPublisher, S3Publisher, VercelPublisher,
+    PgyerPublisher, PlayStorePublisher, PublishConfig, PublishProgressCallback, QiniuPublisher,
+    S3Publisher, VercelPublisher,
 };
 use std::collections::HashMap;
+use std::io::{IsTerminal, Write};
+use std::sync::Arc;
 
 #[derive(Args)]
 pub struct PublishArgs {
     #[arg(long = "path")]
     pub path: Option<String>,
-    #[arg(short, long = "target")]
-    pub target: Option<String>,
+    /// Comma-separated list of target providers to publish to.
+    #[arg(short, long = "targets", alias = "target", value_name = "TARGET,...")]
+    pub targets: Option<String>,
+    /// The version of the app (semantic versioning, e.g. 1.0.0, 2.1.3-beta.1).
+    #[arg(long = "app-version")]
+    pub app_version: Option<String>,
     #[arg(long = "publish-arg", value_name = "KEY=VALUE")]
     pub publish_args: Vec<String>,
 }
@@ -25,16 +32,78 @@ pub async fn execute(args: &PublishArgs) -> Result<()> {
         .clone()
         .ok_or_else(|| anyhow!("The 'path' option is mandatory!"))?;
 
-    let target = args
-        .target
+    let targets: Vec<String> = args
+        .targets
         .as_deref()
-        .ok_or_else(|| anyhow!("The 'target' option is mandatory!"))?
-        .to_ascii_lowercase();
+        .unwrap_or("")
+        .split(',')
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if targets.is_empty() {
+        return Err(anyhow!("At least one 'target' must be specified!"));
+    }
 
-    let publish_arguments = parse_publish_args(&args.publish_args)?;
-    let message = publish_artifact(&artifact_path, &target, publish_arguments)?;
-    println!("{}", message);
+    let mut publish_arguments = parse_publish_args(&args.publish_args)?;
+    if let Some(version) = &args.app_version {
+        publish_arguments
+            .entry("app-version".to_string())
+            .or_insert_with(|| version.clone());
+    }
+
+    for target in &targets {
+        let message = publish_artifact(&artifact_path, target, publish_arguments.clone())?;
+        println!("{}", message);
+    }
     Ok(())
+}
+
+/// Accepts Dart-style `<target>-` prefixed publish arguments (e.g.
+/// `github-repo`, `minio-bucket`): every `<target>-*` key is also made
+/// available without its prefix, mirroring Dart's
+/// `UnifiedDistributor.publish` prefix stripping. Unprefixed keys are kept
+/// as-is, so both conventions work.
+fn resolve_target_arguments(
+    target: &str,
+    publish_arguments: HashMap<String, String>,
+) -> HashMap<String, String> {
+    let prefix = format!("{}-", target);
+    let mut resolved = publish_arguments.clone();
+    for (key, value) in &publish_arguments {
+        if let Some(stripped) = key.strip_prefix(&prefix) {
+            resolved
+                .entry(stripped.to_string())
+                .or_insert_with(|| value.clone());
+        }
+    }
+    resolved
+}
+
+/// Renders upload progress to stderr while publishing (mirrors Dart's
+/// `ProgressBar`). Disabled when stderr is not a terminal.
+fn progress_callback(target: &str) -> Option<PublishProgressCallback> {
+    if !std::io::stderr().is_terminal() {
+        return None;
+    }
+    let target = target.to_string();
+    Some(Arc::new(move |sent: u64, total: u64| {
+        if total == 0 {
+            return;
+        }
+        let percentage = sent * 100 / total;
+        let filled = (percentage / 5) as usize;
+        let bar = format!("{}{}", "█".repeat(filled), "░".repeat(20 - filled));
+        let mut stderr = std::io::stderr();
+        let _ = write!(
+            stderr,
+            "\rPublishing to {}: {} {}/{} {}%",
+            target, bar, sent, total, percentage
+        );
+        if sent >= total {
+            let _ = writeln!(stderr);
+        }
+        let _ = stderr.flush();
+    }))
 }
 
 pub fn publish_artifact(
@@ -43,8 +112,10 @@ pub fn publish_artifact(
     publish_arguments: HashMap<String, String>,
 ) -> Result<String> {
     let target = target.to_ascii_lowercase();
+    let publish_arguments = resolve_target_arguments(&target, publish_arguments);
+    let app_version = publish_arguments.get("app-version").cloned();
     let publish_config = PublishConfig {
-        app_version: None,
+        app_version,
         artifact_path: Some(artifact_path.to_string()),
         publish_arguments: if publish_arguments.is_empty() {
             None
@@ -53,22 +124,25 @@ pub fn publish_artifact(
         },
     };
 
+    let progress = progress_callback(&target);
     let result = match target.as_str() {
-        "s3" | "minio" => S3Publisher::new().publish(publish_config, None),
-        "qiniu" => QiniuPublisher::new().publish(publish_config, None),
-        "oss" => OssPublisher::new().publish(publish_config, None),
-        "cos" => CosPublisher::new().publish(publish_config, None),
-        "fir" => FirPublisher::new().publish(publish_config, None),
-        "firebase" => FirebasePublisher::new().publish(publish_config, None),
-        "firebase-hosting" => FirebaseHostingPublisher::new().publish(publish_config, None),
-        "github" => GitHubPublisher::new().publish(publish_config, None),
-        "appstore" => AppStorePublisher::new().publish(publish_config, None),
-        "appgallery" => AppGalleryPublisher::new().publish(publish_config, None),
-        "vercel" => VercelPublisher::new().publish(publish_config, None),
-        "custom" => CustomPublisher::new().publish(publish_config, None),
+        "s3" | "minio" => S3Publisher::new().publish(publish_config, progress),
+        "qiniu" => QiniuPublisher::new().publish(publish_config, progress),
+        "oss" => OssPublisher::new().publish(publish_config, progress),
+        "cos" => CosPublisher::new().publish(publish_config, progress),
+        "fir" => FirPublisher::new().publish(publish_config, progress),
+        "firebase" => FirebasePublisher::new().publish(publish_config, progress),
+        "firebase-hosting" => FirebaseHostingPublisher::new().publish(publish_config, progress),
+        "github" => GitHubPublisher::new().publish(publish_config, progress),
+        "appstore" => AppStorePublisher::new().publish(publish_config, progress),
+        "appgallery" => AppGalleryPublisher::new().publish(publish_config, progress),
+        "playstore" => PlayStorePublisher::new().publish(publish_config, progress),
+        "pgyer" => PgyerPublisher::new().publish(publish_config, progress),
+        "vercel" => VercelPublisher::new().publish(publish_config, progress),
+        "custom" => CustomPublisher::new().publish(publish_config, progress),
         _ => {
             return Err(anyhow!(
-                "Unsupported publish target: `{}`. Currently supported: s3, qiniu, oss, cos, fir, firebase, firebase-hosting, github, appstore, appgallery, vercel, custom",
+                "Unsupported publish target: `{}`. Currently supported: s3, minio, qiniu, oss, cos, fir, firebase, firebase-hosting, github, appstore, appgallery, playstore, pgyer, vercel, custom",
                 target
             ));
         }

--- a/apps/cli/src/cli/commands/release.rs
+++ b/apps/cli/src/cli/commands/release.rs
@@ -85,6 +85,9 @@ pub async fn execute(args: &ReleaseArgs) -> Result<()> {
         ));
     }
 
+    // Clean at most once across all jobs (mirrors Dart's release flow).
+    let mut clean_before_build = !args.skip_clean;
+
     for release in &matching {
         let filtered_jobs = release.filter_jobs(&job_names, &skip_job_names);
 
@@ -173,10 +176,12 @@ pub async fn execute(args: &ReleaseArgs) -> Result<()> {
                     _vars.clone(),
                     &opts.output,
                     opts.artifact_name.clone(),
-                    !args.skip_clean,
+                    job.package.channel.clone(),
+                    clean_before_build,
                     job.package.hooks.as_ref(),
                 )?
             };
+            clean_before_build = false;
 
             for artifact in &artifacts {
                 println!(

--- a/apps/cli/src/cli/commands/workflow.rs
+++ b/apps/cli/src/cli/commands/workflow.rs
@@ -584,6 +584,7 @@ impl Action for FastforgePackageAction {
                 environment,
                 &output,
                 artifact_name,
+                ctx.inputs.get("channel").cloned(),
                 !skip_clean,
                 hooks.as_ref(),
             )

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -48,8 +48,30 @@ enum Commands {
     GooglePlay(GooglePlayConsoleArgs),
 }
 
+/// Prints the rename notice when the binary is invoked under the legacy
+/// `flutter_distributor` name (mirrors the Dart CLI's banner).
+fn print_rename_notice_if_needed() {
+    let invoked_as = std::env::args()
+        .next()
+        .map(std::path::PathBuf::from)
+        .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().to_string()))
+        .unwrap_or_default();
+    if invoked_as.starts_with("flutter_distributor") {
+        eprintln!(
+            "\x1b[1;33m╔════════════════════════════════════════════════════════════════════════════╗\n\
+             ║ Important Notice: flutter_distributor has been renamed to fastforge.       ║\n\
+             ║ You can continue to use flutter_distributor, but we recommend migrating to ║\n\
+             ║ fastforge for the latest features and updates.                             ║\n\
+             ║                                                                            ║\n\
+             ║ Please visit https://fastforge.dev for more information.                   ║\n\
+             ╚════════════════════════════════════════════════════════════════════════════╝\x1b[0m\n"
+        );
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    print_rename_notice_if_needed();
     let cli = Cli::parse();
 
     match &cli.command {

--- a/apps/cli/tests/package_routing.rs
+++ b/apps/cli/tests/package_routing.rs
@@ -237,6 +237,54 @@ fn flutter_app_macos_pkg() {
 
 #[test]
 #[serial]
+fn flutter_app_android_apk() {
+    let dir = fixture_dir("flutter_app");
+    let dist = dir.join("dist");
+    let _ = fs::remove_dir_all(&dist);
+
+    let run = run_fastforge(
+        &dir,
+        &["package", "--platform", "android", "--target", "apk"],
+    );
+    assert!(
+        run.success,
+        "fastforge package failed:\nstdout: {}\nstderr: {}",
+        run.stdout, run.stderr
+    );
+
+    let apks = find_files_with_ext(&dist, "apk");
+    assert!(!apks.is_empty(), "expected an .apk under {}", dist.display());
+
+    let _ = fs::remove_dir_all(&dist);
+}
+
+#[test]
+#[serial]
+fn flutter_app_macos_multiple_targets() {
+    let dir = fixture_dir("flutter_app");
+    let dist = dir.join("dist");
+    let _ = fs::remove_dir_all(&dist);
+
+    let run = run_fastforge(
+        &dir,
+        &["package", "--platform", "macos", "--targets", "dmg,zip"],
+    );
+    assert!(
+        run.success,
+        "fastforge package failed:\nstdout: {}\nstderr: {}",
+        run.stdout, run.stderr
+    );
+
+    let dmgs = find_files_with_ext(&dist, "dmg");
+    let zips = find_files_with_ext(&dist, "zip");
+    assert!(!dmgs.is_empty(), "expected a .dmg under {}", dist.display());
+    assert!(!zips.is_empty(), "expected a .zip under {}", dist.display());
+
+    let _ = fs::remove_dir_all(&dist);
+}
+
+#[test]
+#[serial]
 fn flutter_app_macos_zip() {
     let dir = fixture_dir("flutter_app");
     let dist = dir.join("dist");

--- a/apps/cli/tests/unsupported_paths.rs
+++ b/apps/cli/tests/unsupported_paths.rs
@@ -1,10 +1,8 @@
-//! Locks in a documented current limitation of `fastforge package`: in a
-//! Flutter project, the packager is currently resolved unconditionally via
-//! `macos_packager(target)` (see `apps/cli/src/cli/commands/package.rs`), so
-//! `--platform android`/`--platform ios` complete the build successfully but
-//! then fail at the packaging step with a specific error. This must fail
-//! loudly and predictably rather than silently changing behavior later
-//! without anyone noticing.
+//! Locks in the error behavior of `fastforge package` for genuinely
+//! unsupported `(platform, target)` pairs: the packager registry
+//! (`resolve_packager` in `apps/cli/src/cli/commands/package.rs`) must reject
+//! mismatched combinations loudly and predictably instead of silently
+//! producing the wrong artifact.
 
 mod support;
 
@@ -12,21 +10,19 @@ use std::fs;
 use support::{fixture_dir, run_fastforge};
 
 #[test]
-fn flutter_app_android_apk_package_is_unsupported() {
+fn flutter_app_macos_apk_package_is_unsupported() {
     let dir = fixture_dir("flutter_app");
     let dist = dir.join("dist");
     let _ = fs::remove_dir_all(&dist);
 
-    let run = run_fastforge(
-        &dir,
-        &["package", "--platform", "android", "--target", "apk"],
-    );
+    // `apk` is an Android format; requesting it for macOS must fail at
+    // packager resolution with the documented error message.
+    let run = run_fastforge(&dir, &["package", "--platform", "macos", "--target", "apk"]);
 
     assert!(
         !run.success,
-        "expected `fastforge package --platform android` to fail in a Flutter \
-         project (packager selection is currently hardcoded to macOS formats); \
-         stdout: {}\nstderr: {}",
+        "expected `fastforge package --platform macos --target apk` to fail \
+         (apk is not a macOS package format); stdout: {}\nstderr: {}",
         run.stdout, run.stderr
     );
     assert!(
@@ -36,4 +32,22 @@ fn flutter_app_android_apk_package_is_unsupported() {
     );
 
     let _ = fs::remove_dir_all(&dist);
+}
+
+#[test]
+fn package_requires_at_least_one_target() {
+    let dir = fixture_dir("flutter_app");
+
+    let run = run_fastforge(&dir, &["package", "--platform", "macos"]);
+
+    assert!(
+        !run.success,
+        "expected `fastforge package` without --targets to fail; stdout: {}\nstderr: {}",
+        run.stdout, run.stderr
+    );
+    assert!(
+        run.stderr.contains("At least one 'target' must be specified"),
+        "expected the missing-target error, got:\n{}",
+        run.stderr
+    );
 }

--- a/apps/docs/en/makers/appimage.md
+++ b/apps/docs/en/makers/appimage.md
@@ -58,6 +58,8 @@ categories:
   - Music
 
 startup_notify: true
+# Maps windows to this desktop entry (e.g. GTK application-id) so GNOME/KDE group the app icon correctly.
+# startup_wm_class: com.example.hello_world
 
 # You can specify the shared libraries that you want to bundle with your app
 #

--- a/apps/docs/zh/makers/appimage.md
+++ b/apps/docs/zh/makers/appimage.md
@@ -58,6 +58,8 @@ categories:
   - Music
 
 startup_notify: true
+# 将窗口映射到该桌面入口（例如 GTK application-id），便于 GNOME/KDE 正确关联应用图标。
+# startup_wm_class: com.example.hello_world
 
 # 您可以指定要与您的应用捆绑的共享库
 #

--- a/crates/app_packager/src/custom.rs
+++ b/crates/app_packager/src/custom.rs
@@ -1,0 +1,225 @@
+use std::path::Path;
+use std::process::Command;
+
+use fastforge_core::{AppPackager, PackageConfig, PackageError, PackageResult, Platform};
+use serde::Deserialize;
+
+/// Runs a user-provided script to produce the package artifact, mirroring
+/// Dart's `AppPackageMakerCustom`.
+///
+/// The script and output extension are read from
+/// `<platform>/packaging/custom/make_config.yaml`:
+///
+/// ```yaml
+/// script: ./scripts/package.sh
+/// # Omit or leave empty to produce a directory artifact instead of a file.
+/// output_extension: tar.gz
+/// ```
+///
+/// The script receives the following environment variables:
+/// `APP_NAME`, `APP_VERSION`, `BUILD_NAME`, `BUILD_NUMBER` (when present),
+/// `BUILD_MODE`, `FLAVOR` (when present), `CHANNEL` (when present),
+/// `BUILD_OUTPUT_DIRECTORY`, `OUTPUT_DIRECTORY`, `OUTPUT_ARTIFACT_PATH`.
+#[derive(Debug)]
+pub struct CustomPackager {
+    platform: Platform,
+    pub script: String,
+    pub output_extension: String,
+}
+
+#[derive(Deserialize)]
+struct CustomMakeConfig {
+    script: String,
+    #[serde(default)]
+    output_extension: String,
+}
+
+impl CustomPackager {
+    pub fn new(platform: Platform, script: String, output_extension: String) -> Self {
+        Self {
+            platform,
+            script,
+            output_extension,
+        }
+    }
+
+    /// Load the packager configuration from
+    /// `<platform>/packaging/custom/make_config.yaml`.
+    pub fn load(platform: Platform) -> Result<Self, PackageError> {
+        let path = format!("{}/packaging/custom/make_config.yaml", platform.as_str());
+        Self::from_yaml_file(platform, Path::new(&path))
+    }
+
+    pub fn from_yaml_file(platform: Platform, path: &Path) -> Result<Self, PackageError> {
+        if !path.exists() {
+            return Err(PackageError::NotFound(format!(
+                "Custom packager requires a config file at {}",
+                path.display()
+            )));
+        }
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            PackageError::General(format!("Failed to read {}: {}", path.display(), e))
+        })?;
+        let cfg: CustomMakeConfig = serde_yaml::from_str(&content).map_err(|e| {
+            PackageError::General(format!("Failed to parse {}: {}", path.display(), e))
+        })?;
+        Ok(Self::new(platform, cfg.script, cfg.output_extension))
+    }
+}
+
+impl AppPackager for CustomPackager {
+    fn name(&self) -> &str {
+        "custom"
+    }
+
+    fn platform(&self) -> Platform {
+        self.platform
+    }
+
+    fn package_format(&self) -> &str {
+        &self.output_extension
+    }
+
+    fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
+        // The artifact path uses the configured output extension instead of
+        // the `custom` placeholder format.
+        let mut effective = config.clone();
+        effective.package_format = self.output_extension.clone();
+        let output_path = effective.output_file();
+
+        let build_name = effective
+            .app_version
+            .split('+')
+            .next()
+            .unwrap_or(&effective.app_version)
+            .to_string();
+        let build_number = effective.app_version.split('+').nth(1).map(str::to_string);
+
+        let (shell, flag) = if cfg!(target_os = "windows") {
+            ("cmd", "/c")
+        } else {
+            ("sh", "-c")
+        };
+
+        let mut cmd = Command::new(shell);
+        cmd.args([flag, &self.script]);
+        cmd.env("APP_NAME", &effective.app_name)
+            .env("APP_VERSION", &effective.app_version)
+            .env("BUILD_NAME", build_name)
+            .env("BUILD_MODE", &effective.build_mode)
+            .env("BUILD_OUTPUT_DIRECTORY", &effective.build_output_dir)
+            .env("OUTPUT_DIRECTORY", &effective.output_dir)
+            .env("OUTPUT_ARTIFACT_PATH", &output_path);
+        if let Some(number) = build_number {
+            cmd.env("BUILD_NUMBER", number);
+        }
+        if let Some(flavor) = &effective.flavor {
+            cmd.env("FLAVOR", flavor);
+        }
+        if let Some(channel) = &effective.channel {
+            cmd.env("CHANNEL", channel);
+        }
+
+        let out = cmd.output().map_err(|e| {
+            PackageError::MissingTool(format!("{}: {}", shell, e))
+        })?;
+        if !out.status.success() {
+            return Err(PackageError::CommandFailed {
+                command: self.script.clone(),
+                stderr: String::from_utf8_lossy(&out.stderr).into(),
+            });
+        }
+
+        Ok(PackageResult {
+            artifacts: vec![output_path],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn write_config(dir: &Path, platform: &str, yaml: &str) -> std::path::PathBuf {
+        let cfg_dir = dir.join(platform).join("packaging").join("custom");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        let path = cfg_dir.join("make_config.yaml");
+        std::fs::write(&path, yaml).unwrap();
+        path
+    }
+
+    #[test]
+    fn loads_script_and_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_config(
+            dir.path(),
+            "linux",
+            "script: ./scripts/package.sh\noutput_extension: tar.gz\n",
+        );
+        let packager = CustomPackager::from_yaml_file(Platform::Linux, &path).unwrap();
+        assert_eq!(packager.script, "./scripts/package.sh");
+        assert_eq!(packager.output_extension, "tar.gz");
+        assert_eq!(packager.package_format(), "tar.gz");
+    }
+
+    #[test]
+    fn missing_config_is_an_error() {
+        let err = CustomPackager::from_yaml_file(
+            Platform::Linux,
+            Path::new("/nonexistent/make_config.yaml"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("make_config.yaml"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runs_script_with_environment() {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join("dist");
+        let capture = dir.path().join("env.txt");
+        let script = format!(
+            "echo \"$APP_NAME|$APP_VERSION|$BUILD_NAME|$BUILD_NUMBER|$BUILD_MODE|$FLAVOR|$CHANNEL\" > {} && touch \"$OUTPUT_ARTIFACT_PATH\"",
+            capture.display()
+        );
+        let packager =
+            CustomPackager::new(Platform::Linux, script, "tar.gz".to_string());
+
+        let config = PackageConfig {
+            app_name: "demo".into(),
+            app_binary_name: "demo".into(),
+            app_version: "1.0.0+7".into(),
+            build_mode: "release".into(),
+            platform: Platform::Linux,
+            flavor: Some("dev".into()),
+            channel: Some("beta".into()),
+            artifact_name: None,
+            package_format: "custom".into(),
+            is_installer: false,
+            build_output_dir: dir.path().to_path_buf(),
+            build_output_files: vec![],
+            output_dir: out_dir.clone(),
+        };
+
+        let result = packager.package(&config).unwrap();
+        let artifact = &result.artifacts[0];
+        assert!(artifact.exists(), "script should create the artifact");
+        assert!(
+            artifact.to_string_lossy().ends_with(".tar.gz"),
+            "artifact should use the configured extension: {}",
+            artifact.display()
+        );
+
+        let captured = std::fs::read_to_string(&capture).unwrap();
+        let parts: HashMap<usize, &str> =
+            captured.trim().split('|').enumerate().collect();
+        assert_eq!(parts[&0], "demo");
+        assert_eq!(parts[&1], "1.0.0+7");
+        assert_eq!(parts[&2], "1.0.0");
+        assert_eq!(parts[&3], "7");
+        assert_eq!(parts[&4], "release");
+        assert_eq!(parts[&5], "dev");
+        assert_eq!(parts[&6], "beta");
+    }
+}

--- a/crates/app_packager/src/lib.rs
+++ b/crates/app_packager/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod android;
+pub mod custom;
 pub mod ios;
 pub mod linux;
 pub mod macos;
@@ -11,6 +12,7 @@ pub use fastforge_core::{AppPackager, PackageConfig, PackageError, PackageResult
 // Re-export all packagers for convenient access.
 pub use android::aab::AndroidAabPackager;
 pub use android::apk::AndroidApkPackager;
+pub use custom::CustomPackager;
 pub use ios::ipa::IOSIpaPackager;
 pub use linux::appimage::LinuxAppImagePackager;
 pub use linux::deb::LinuxDebPackager;

--- a/crates/app_packager/src/linux/appimage.rs
+++ b/crates/app_packager/src/linux/appimage.rs
@@ -1,12 +1,145 @@
+use std::collections::BTreeSet;
+use std::path::Path;
 use std::process::Command;
 
 use fastforge_core::{AppPackager, PackageConfig, PackageError, PackageResult, Platform};
+use serde::Deserialize;
+
+use super::common::{load_make_config, uname_machine};
 
 /// Builds a Linux AppImage using `appimagetool`, mirroring Dart's
 /// `AppPackageMakerAppImage`.
 ///
-/// Requires `appimagetool` to be on `$PATH`.
+/// Reads `linux/packaging/appimage/make_config.yaml` when present (same
+/// schema as Dart's `MakeAppImageConfig`); falls back to sensible defaults
+/// otherwise.
+///
+/// Requires `appimagetool` (plus `ldd` and `locate` for dependency bundling)
+/// to be on `$PATH`.
 pub struct LinuxAppImagePackager;
+
+/// A desktop action entry (`[Desktop Action <label>]`), mirroring Dart's
+/// `AppImageAction`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AppImageAction {
+    pub label: String,
+    pub name: String,
+    #[serde(default)]
+    pub arguments: Vec<String>,
+}
+
+/// Schema of `linux/packaging/appimage/make_config.yaml`, mirroring Dart's
+/// `MakeAppImageConfig.fromJson`.
+#[derive(Debug, Default, Deserialize)]
+pub struct AppImageMakeConfig {
+    pub display_name: Option<String>,
+    pub icon: Option<String>,
+    pub metainfo: Option<String>,
+    #[serde(default)]
+    pub include: Vec<String>,
+    #[serde(default)]
+    pub keywords: Vec<String>,
+    #[serde(default)]
+    pub categories: Vec<String>,
+    #[serde(default)]
+    pub actions: Vec<AppImageAction>,
+    pub startup_notify: Option<bool>,
+    pub generic_name: Option<String>,
+    pub supported_mime_type: Option<Vec<String>>,
+}
+
+impl AppImageMakeConfig {
+    fn load() -> Result<Self, PackageError> {
+        Ok(
+            load_make_config(Path::new("linux/packaging/appimage/make_config.yaml"))?
+                .unwrap_or_default(),
+        )
+    }
+
+    /// Renders the desktop file, mirroring Dart's `desktopFileContent`
+    /// (including `[Desktop Action]` sections).
+    fn desktop_file(&self, config: &PackageConfig) -> String {
+        let app_name = &config.app_name;
+        let mut fields: Vec<(&str, String)> = vec![
+            (
+                "Name",
+                self.display_name
+                    .clone()
+                    .unwrap_or_else(|| app_name.clone()),
+            ),
+            (
+                "GenericName",
+                self.generic_name
+                    .clone()
+                    .unwrap_or_else(|| "A Flutter Application".to_string()),
+            ),
+            (
+                "Exec",
+                format!("LD_LIBRARY_PATH=usr/lib {} %u", app_name),
+            ),
+            ("Icon", app_name.clone()),
+            ("Type", "Application".to_string()),
+            (
+                "StartupNotify",
+                self.startup_notify.unwrap_or(false).to_string(),
+            ),
+        ];
+        if let Some(mime) = self
+            .supported_mime_type
+            .as_ref()
+            .filter(|v| !v.is_empty())
+        {
+            fields.push(("MimeType", format!("{};", mime.join(";"))));
+        }
+        if !self.categories.is_empty() {
+            fields.push(("Categories", self.categories.join(";")));
+        }
+        if !self.keywords.is_empty() {
+            fields.push(("Keywords", self.keywords.join(";")));
+        }
+        if !self.actions.is_empty() {
+            fields.push((
+                "Actions",
+                self.actions
+                    .iter()
+                    .map(|a| a.label.clone())
+                    .collect::<Vec<_>>()
+                    .join(";"),
+            ));
+        }
+
+        let entry = fields
+            .into_iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let actions = self
+            .actions
+            .iter()
+            .map(|action| {
+                format!(
+                    "[Desktop Action {}]\nName={}\nExec=LD_LIBRARY_PATH=usr/lib {} {} %u",
+                    action.label,
+                    action.name,
+                    app_name,
+                    action.arguments.join(" "),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        format!("[Desktop Entry]\n{}\n\n{}", entry, actions)
+    }
+
+    /// Renders the `AppRun` launcher script, mirroring Dart's `appRunContent`.
+    fn app_run(&self, config: &PackageConfig) -> String {
+        format!(
+            "#!/bin/bash\n\ncd \"$(dirname \"$0\")\"\nexport LD_LIBRARY_PATH=usr/lib\nexec ./{}\n",
+            config.app_name
+        )
+    }
+}
 
 fn run(cmd: &mut Command) -> Result<(), PackageError> {
     let out = cmd.output().map_err(|e| {
@@ -19,6 +152,39 @@ fn run(cmd: &mut Command) -> Result<(), PackageError> {
         });
     }
     Ok(())
+}
+
+fn run_stdout(cmd: &mut Command) -> Result<String, PackageError> {
+    let out = cmd.output().map_err(|e| {
+        PackageError::MissingTool(format!("{}: {}", cmd.get_program().to_string_lossy(), e))
+    })?;
+    if !out.status.success() {
+        return Err(PackageError::CommandFailed {
+            command: cmd.get_program().to_string_lossy().into(),
+            stderr: String::from_utf8_lossy(&out.stderr).into(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+/// Parses `ldd` output into resolved shared-object paths, mirroring Dart's
+/// `_getSharedDependencies`.
+fn parse_ldd_output(output: &str) -> BTreeSet<String> {
+    output
+        .lines()
+        .filter(|line| line.contains("=>") && line.trim().starts_with("lib"))
+        .filter_map(|line| {
+            line.split(" => ")
+                .nth(1)
+                .and_then(|rest| rest.trim().split(' ').next())
+                .map(|s| s.trim().to_string())
+        })
+        .collect()
+}
+
+fn shared_dependencies(so_path: &Path) -> Result<BTreeSet<String>, PackageError> {
+    let output = run_stdout(Command::new("ldd").args(["-d", &so_path.display().to_string()]))?;
+    Ok(parse_ldd_output(&output))
 }
 
 impl AppPackager for LinuxAppImagePackager {
@@ -40,9 +206,16 @@ impl AppPackager for LinuxAppImagePackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
+        let make_config = AppImageMakeConfig::load()?;
+
+        // The artifact uses the `.AppImage` extension (mirrors Dart, which
+        // overrides packageFormat to `AppImage` for the output file).
+        let mut effective = config.clone();
+        effective.package_format = "AppImage".to_string();
+        let output_file = effective.output_file();
+
         let pkg_dir = config.packaging_dir();
         let app_name = &config.app_name;
-        let binary_name = &config.app_binary_name;
 
         let app_dir = pkg_dir.join(format!("{}.AppDir", app_name));
         std::fs::create_dir_all(&app_dir)?;
@@ -54,40 +227,215 @@ impl AppPackager for LinuxAppImagePackager {
             &app_dir.display().to_string(),
         ]))?;
 
-        // Write AppRun script – flutter Linux builds place the binary in lib/
-        // (named after the app), or directly in the AppDir root.
-        let app_run_path = app_dir.join("AppRun");
+        // Write .desktop file and AppRun
         std::fs::write(
-            &app_run_path,
-            format!(
-                "#!/usr/bin/env sh\nHERE=\"$(dirname \"$(readlink -f \"$0\")\")\"\nexec \"$HERE/{bin}\" \"$@\"\n",
-                bin = binary_name,
-            ),
+            app_dir.join(format!("{}.desktop", app_name)),
+            make_config.desktop_file(config),
         )?;
+        let app_run_path = app_dir.join("AppRun");
+        std::fs::write(&app_run_path, make_config.app_run(config))?;
         run(Command::new("chmod").args(["+x", &app_run_path.display().to_string()]))?;
 
-        // Write .desktop file
-        let desktop = format!(
-            "[Desktop Entry]\nType=Application\nName={name}\nExec={bin}\nIcon={bin}\nCategories=Utility;\n",
-            name = config.app_name,
-            bin = binary_name,
-        );
-        let desktop_path = app_dir.join(format!("{}.desktop", app_name));
-        std::fs::write(&desktop_path, &desktop)?;
+        // Install the configured icon at AppDir root and in hicolor dirs
+        if let Some(icon) = &make_config.icon {
+            let icon_path = Path::new(icon);
+            if !icon_path.exists() {
+                return Err(PackageError::NotFound(format!(
+                    "icon {} path doesn't exist",
+                    icon
+                )));
+            }
+            let ext = icon_path
+                .extension()
+                .map(|e| format!(".{}", e.to_string_lossy()))
+                .unwrap_or_default();
+            std::fs::copy(icon_path, app_dir.join(format!("{}{}", app_name, ext)))?;
+            for size in ["128x128", "256x256"] {
+                let dir = app_dir
+                    .join("usr/share/icons/hicolor")
+                    .join(size)
+                    .join("apps");
+                std::fs::create_dir_all(&dir)?;
+                std::fs::copy(icon_path, dir.join(format!("{}{}", app_name, ext)))?;
+            }
+        }
 
-        // Build the AppImage (output format is `.AppImage`)
-        let output_file = config.output_file();
+        // Install the configured metainfo
+        if let Some(metainfo) = &make_config.metainfo {
+            let metainfo_path = Path::new(metainfo);
+            if !metainfo_path.exists() {
+                return Err(PackageError::NotFound(format!(
+                    "Metainfo {} path doesn't exist",
+                    metainfo
+                )));
+            }
+            let file_name = metainfo_path
+                .file_name()
+                .map(|f| f.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let ext = {
+                let parts: Vec<&str> = file_name.split('.').collect();
+                match parts.len() {
+                    0 | 1 => String::new(),
+                    2 => format!(".{}", parts[1]),
+                    n => format!(".{}.{}", parts[n - 2], parts[n - 1]),
+                }
+            };
+            let metainfo_dir = app_dir.join("usr/share/metainfo");
+            std::fs::create_dir_all(&metainfo_dir)?;
+            std::fs::copy(
+                metainfo_path,
+                metainfo_dir.join(format!("{}{}", config.app_binary_name, ext)),
+            )?;
+        }
+
+        // Bundle shared-object dependencies of plugin libraries into usr/lib
+        // (mirrors Dart: deps of each lib/*.so, minus the flutter GTK deps).
+        let usr_lib = app_dir.join("usr/lib");
+        std::fs::create_dir_all(&usr_lib)?;
+
+        let default_shared_objects = ["libapp.so", "libflutter_linux_gtk.so", "libgtk-3.so.0"];
+        let lib_dir = app_dir.join("lib");
+        let gtk_so = lib_dir.join("libflutter_linux_gtk.so");
+        if gtk_so.exists() {
+            let gtk_deps = shared_dependencies(&gtk_so)?;
+            if let Ok(entries) = std::fs::read_dir(&lib_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if !path.is_file() {
+                        continue;
+                    }
+                    let base = path
+                        .file_name()
+                        .map(|f| f.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    if default_shared_objects.contains(&base.as_str()) {
+                        continue;
+                    }
+                    let mut deps = shared_dependencies(&path)?;
+                    deps = deps.difference(&gtk_deps).cloned().collect();
+                    deps.retain(|lib| !lib.contains("libflutter_linux_gtk.so"));
+                    if deps.is_empty() {
+                        continue;
+                    }
+                    let mut args: Vec<String> = deps.into_iter().collect();
+                    args.push(usr_lib.display().to_string());
+                    run(Command::new("cp").args(&args))?;
+                }
+            }
+        }
+
+        // Copy explicitly included shared objects (resolved via `locate`)
+        for so in &make_config.include {
+            let output = run_stdout(Command::new("locate").arg(so))?;
+            let found = output
+                .lines()
+                .map(str::trim)
+                .find(|p| !p.is_empty() && !p.contains("/Trash"))
+                .ok_or_else(|| {
+                    PackageError::NotFound(format!("Can't find specified shared object {}", so))
+                })?;
+            let src = Path::new(found);
+            let base = src
+                .file_name()
+                .map(|f| f.to_string_lossy().to_string())
+                .unwrap_or_default();
+            std::fs::copy(src, usr_lib.join(base))?;
+        }
+
+        // Build the AppImage
+        let arch = if uname_machine() == "aarch64" {
+            "aarch64"
+        } else {
+            "x86_64"
+        };
         run(Command::new("appimagetool")
             .args([
                 "--no-appstream",
                 &app_dir.display().to_string(),
                 &output_file.display().to_string(),
             ])
-            .env("ARCH", "x86_64"))?;
+            .env("ARCH", arch))?;
 
         std::fs::remove_dir_all(&pkg_dir).ok();
         Ok(PackageResult {
             artifacts: vec![output_file],
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_config() -> PackageConfig {
+        PackageConfig {
+            app_name: "hola_amigos".into(),
+            app_binary_name: "hola_amigos".into(),
+            app_version: "1.2.3+4".into(),
+            build_mode: "release".into(),
+            platform: Platform::Linux,
+            flavor: None,
+            channel: None,
+            artifact_name: None,
+            package_format: "appimage".into(),
+            is_installer: false,
+            build_output_dir: PathBuf::new(),
+            build_output_files: vec![],
+            output_dir: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn desktop_file_with_actions() {
+        let mc: AppImageMakeConfig = serde_yaml::from_str(
+            r#"
+display_name: Hola Amigos
+icon: assets/logo.png
+categories:
+  - Music
+  - Media
+keywords:
+  - Hello
+supported_mime_type:
+  - audio/mpeg
+actions:
+  - label: Gallery
+    name: Open Gallery
+    arguments:
+      - --gallery
+"#,
+        )
+        .unwrap();
+        let desktop = mc.desktop_file(&test_config());
+        assert!(desktop.contains("Name=Hola Amigos"));
+        assert!(desktop.contains("GenericName=A Flutter Application"));
+        assert!(desktop.contains("Exec=LD_LIBRARY_PATH=usr/lib hola_amigos %u"));
+        assert!(desktop.contains("MimeType=audio/mpeg;"));
+        assert!(desktop.contains("Categories=Music;Media"));
+        assert!(desktop.contains("Keywords=Hello"));
+        assert!(desktop.contains("Actions=Gallery"));
+        assert!(desktop.contains("[Desktop Action Gallery]"));
+        assert!(desktop.contains("Name=Open Gallery"));
+        assert!(desktop.contains("Exec=LD_LIBRARY_PATH=usr/lib hola_amigos --gallery %u"));
+    }
+
+    #[test]
+    fn app_run_script() {
+        let script = AppImageMakeConfig::default().app_run(&test_config());
+        assert!(script.starts_with("#!/bin/bash"));
+        assert!(script.contains("export LD_LIBRARY_PATH=usr/lib"));
+        assert!(script.contains("exec ./hola_amigos"));
+    }
+
+    #[test]
+    fn ldd_output_parsing() {
+        let output = "\tlinux-vdso.so.1 (0x00007ffd)\n\tlibkeybinder-3.0.so.0 => /lib64/libkeybinder-3.0.so.0 (0x00007f65)\n\tlibc.so.6 => /lib64/libc.so.6 (0x00007f64)\n\t/lib64/ld-linux-x86-64.so.2 (0x00007f66)\n";
+        let deps = parse_ldd_output(output);
+        assert_eq!(
+            deps.into_iter().collect::<Vec<_>>(),
+            vec!["/lib64/libc.so.6", "/lib64/libkeybinder-3.0.so.0"]
+        );
     }
 }

--- a/crates/app_packager/src/linux/appimage.rs
+++ b/crates/app_packager/src/linux/appimage.rs
@@ -44,6 +44,7 @@ pub struct AppImageMakeConfig {
     #[serde(default)]
     pub actions: Vec<AppImageAction>,
     pub startup_notify: Option<bool>,
+    pub startup_wm_class: Option<String>,
     pub generic_name: Option<String>,
     pub supported_mime_type: Option<Vec<String>>,
 }
@@ -84,6 +85,13 @@ impl AppImageMakeConfig {
                 self.startup_notify.unwrap_or(false).to_string(),
             ),
         ];
+        if let Some(wm) = self
+            .startup_wm_class
+            .as_ref()
+            .filter(|s| !s.is_empty())
+        {
+            fields.push(("StartupWMClass", wm.clone()));
+        }
         if let Some(mime) = self
             .supported_mime_type
             .as_ref()
@@ -400,6 +408,7 @@ keywords:
   - Hello
 supported_mime_type:
   - audio/mpeg
+startup_wm_class: com.example.hola_amigos
 actions:
   - label: Gallery
     name: Open Gallery
@@ -412,6 +421,7 @@ actions:
         assert!(desktop.contains("Name=Hola Amigos"));
         assert!(desktop.contains("GenericName=A Flutter Application"));
         assert!(desktop.contains("Exec=LD_LIBRARY_PATH=usr/lib hola_amigos %u"));
+        assert!(desktop.contains("StartupWMClass=com.example.hola_amigos"));
         assert!(desktop.contains("MimeType=audio/mpeg;"));
         assert!(desktop.contains("Categories=Music;Media"));
         assert!(desktop.contains("Keywords=Hello"));
@@ -419,6 +429,20 @@ actions:
         assert!(desktop.contains("[Desktop Action Gallery]"));
         assert!(desktop.contains("Name=Open Gallery"));
         assert!(desktop.contains("Exec=LD_LIBRARY_PATH=usr/lib hola_amigos --gallery %u"));
+    }
+
+    #[test]
+    fn desktop_file_omits_empty_startup_wm_class() {
+        let mc: AppImageMakeConfig = serde_yaml::from_str(
+            r#"
+display_name: Hola Amigos
+icon: assets/logo.png
+startup_wm_class: ""
+"#,
+        )
+        .unwrap();
+        let desktop = mc.desktop_file(&test_config());
+        assert!(!desktop.contains("StartupWMClass"));
     }
 
     #[test]

--- a/crates/app_packager/src/linux/common.rs
+++ b/crates/app_packager/src/linux/common.rs
@@ -1,0 +1,197 @@
+//! Helpers shared by the Linux packagers (deb / rpm / pacman / appimage),
+//! mirroring the pieces of Dart's `MakeLinuxPackageConfig` and maker
+//! implementations that are common across formats.
+
+use std::path::Path;
+
+use fastforge_core::PackageError;
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+/// Loads a maker's `make_config.yaml`. Returns `Ok(None)` when the file does
+/// not exist so callers can fall back to defaults (Dart requires the file for
+/// deb/rpm/pacman/appimage; the Rust CLI keeps working without one, using the
+/// same defaults as before).
+pub(crate) fn load_make_config<T: DeserializeOwned>(
+    path: &Path,
+) -> Result<Option<T>, PackageError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| PackageError::General(format!("Failed to read {}: {}", path.display(), e)))?;
+    let value: T = serde_yaml::from_str(&content)
+        .map_err(|e| PackageError::General(format!("Failed to parse {}: {}", path.display(), e)))?;
+    Ok(Some(value))
+}
+
+/// `name`/`email` pair used by `maintainer:` and `co_authors:` entries.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Person {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub email: String,
+}
+
+impl Person {
+    /// Renders as `Name <email>`, matching Dart's formatting.
+    pub fn formatted(&self) -> String {
+        format!("{} <{}>", self.name, self.email)
+    }
+}
+
+/// Machine architecture from `uname -m` (e.g. `x86_64`, `aarch64`).
+pub(crate) fn uname_machine() -> String {
+    std::process::Command::new("uname")
+        .arg("-m")
+        .output()
+        .ok()
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| std::env::consts::ARCH.to_string())
+}
+
+/// Debian-style architecture name, mirroring Dart's `_getArchitecture`.
+pub(crate) fn deb_architecture() -> &'static str {
+    if uname_machine() == "aarch64" {
+        "arm64"
+    } else {
+        "amd64"
+    }
+}
+
+/// `description` / `homepage` read from the project's `pubspec.yaml`
+/// (used by deb's `Description:`/`Homepage:` control fields and rpm's
+/// `%description`).
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct PubspecMeta {
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub homepage: Option<String>,
+}
+
+pub(crate) fn load_pubspec_meta() -> PubspecMeta {
+    std::fs::read_to_string("pubspec.yaml")
+        .ok()
+        .and_then(|content| serde_yaml::from_str(&content).ok())
+        .unwrap_or_default()
+}
+
+/// Renders a `[Desktop Entry]` file from `(key, Option<value>)` pairs,
+/// skipping entries whose value is `None`.
+pub(crate) fn render_desktop_entry(entries: &[(&str, Option<String>)]) -> String {
+    let mut lines = vec!["[Desktop Entry]".to_string()];
+    for (key, value) in entries {
+        if let Some(value) = value {
+            lines.push(format!("{}={}", key, value));
+        }
+    }
+    lines.join("\n")
+}
+
+/// Joins list values as `a;b;c;` (freedesktop list syntax); `None` when empty.
+pub(crate) fn desktop_list(values: &Option<Vec<String>>) -> Option<String> {
+    values
+        .as_ref()
+        .filter(|v| !v.is_empty())
+        .map(|v| format!("{};", v.join(";")))
+}
+
+/// Copies the icon configured in `make_config.yaml` into
+/// `usr/share/icons/hicolor/{128x128,256x256}/apps/<binary><ext>`,
+/// mirroring Dart's deb/rpm maker behavior.
+pub(crate) fn install_hicolor_icons(
+    icon: &str,
+    packaging_root: &Path,
+    binary_name: &str,
+) -> Result<(), PackageError> {
+    let icon_path = Path::new(icon);
+    if !icon_path.exists() {
+        return Err(PackageError::NotFound(format!(
+            "provided icon {} path wasn't found",
+            icon
+        )));
+    }
+    let ext = icon_path
+        .extension()
+        .map(|e| format!(".{}", e.to_string_lossy()))
+        .unwrap_or_default();
+    for size in ["128x128", "256x256"] {
+        let dir = packaging_root
+            .join("usr/share/icons/hicolor")
+            .join(size)
+            .join("apps");
+        std::fs::create_dir_all(&dir)?;
+        std::fs::copy(icon_path, dir.join(format!("{}{}", binary_name, ext)))?;
+    }
+    Ok(())
+}
+
+/// Copies a metainfo XML into `usr/share/metainfo/<binary>.appdata.xml`
+/// (double extension preserved, mirroring Dart's `path.extension(..., 2)`).
+pub(crate) fn install_metainfo(
+    metainfo: &str,
+    packaging_root: &Path,
+    binary_name: &str,
+) -> Result<(), PackageError> {
+    let metainfo_path = Path::new(metainfo);
+    if !metainfo_path.exists() {
+        return Err(PackageError::NotFound(format!(
+            "Metainfo {} path wasn't found",
+            metainfo
+        )));
+    }
+    let file_name = metainfo_path
+        .file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_default();
+    // Keep up to two extensions (e.g. `.appdata.xml`).
+    let ext = {
+        let parts: Vec<&str> = file_name.split('.').collect();
+        match parts.len() {
+            0 | 1 => String::new(),
+            2 => format!(".{}", parts[1]),
+            n => format!(".{}.{}", parts[n - 2], parts[n - 1]),
+        }
+    };
+    let dir = packaging_root.join("usr/share/metainfo");
+    std::fs::create_dir_all(&dir)?;
+    std::fs::copy(metainfo_path, dir.join(format!("{}{}", binary_name, ext)))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desktop_entry_skips_none() {
+        let out = render_desktop_entry(&[
+            ("Type", Some("Application".into())),
+            ("GenericName", None),
+            ("Name", Some("Demo".into())),
+        ]);
+        assert_eq!(out, "[Desktop Entry]\nType=Application\nName=Demo");
+    }
+
+    #[test]
+    fn desktop_list_formatting() {
+        assert_eq!(
+            desktop_list(&Some(vec!["Music".into(), "Media".into()])),
+            Some("Music;Media;".to_string())
+        );
+        assert_eq!(desktop_list(&Some(vec![])), None);
+        assert_eq!(desktop_list(&None), None);
+    }
+
+    #[test]
+    fn person_formatting() {
+        let p = Person {
+            name: "Gamer Boy 69".into(),
+            email: "rickastley@gmail.lol".into(),
+        };
+        assert_eq!(p.formatted(), "Gamer Boy 69 <rickastley@gmail.lol>");
+    }
+}

--- a/crates/app_packager/src/linux/deb.rs
+++ b/crates/app_packager/src/linux/deb.rs
@@ -2,12 +2,191 @@ use std::path::Path;
 use std::process::Command;
 
 use fastforge_core::{AppPackager, PackageConfig, PackageError, PackageResult, Platform};
+use serde::Deserialize;
+
+use super::common::{
+    Person, deb_architecture, desktop_list, install_hicolor_icons, install_metainfo,
+    load_make_config, load_pubspec_meta, render_desktop_entry,
+};
 
 /// Builds a Debian `.deb` package using `dpkg-deb`, mirroring
 /// Dart's `AppPackageMakerDeb`.
 ///
+/// Reads `linux/packaging/deb/make_config.yaml` when present (same schema as
+/// Dart's `MakeDebConfig`); falls back to sensible defaults otherwise.
+///
 /// Requires `dpkg-deb` to be installed on the host (`dpkg-dev` on Debian/Ubuntu).
 pub struct LinuxDebPackager;
+
+/// Schema of `linux/packaging/deb/make_config.yaml`, mirroring Dart's
+/// `MakeDebConfig.fromJson`.
+#[derive(Debug, Default, Deserialize)]
+pub struct DebMakeConfig {
+    pub display_name: Option<String>,
+    pub package_name: Option<String>,
+    pub maintainer: Option<Person>,
+    pub co_authors: Option<Vec<Person>>,
+    pub priority: Option<String>,
+    pub section: Option<String>,
+    pub installed_size: Option<i64>,
+    pub essential: Option<bool>,
+    pub dependencies: Option<Vec<String>>,
+    pub build_dependencies_indep: Option<Vec<String>>,
+    pub build_dependencies: Option<Vec<String>>,
+    pub recommended_dependencies: Option<Vec<String>>,
+    pub suggested_dependencies: Option<Vec<String>>,
+    pub enhances: Option<Vec<String>>,
+    pub pre_dependencies: Option<Vec<String>>,
+    pub breaks: Option<Vec<String>>,
+    pub conflicts: Option<Vec<String>>,
+    pub provides: Option<Vec<String>>,
+    pub replaces: Option<Vec<String>>,
+    pub postinstall_scripts: Option<Vec<String>>,
+    pub postuninstall_scripts: Option<Vec<String>>,
+    pub keywords: Option<Vec<String>>,
+    pub supported_mime_type: Option<Vec<String>>,
+    pub actions: Option<Vec<String>>,
+    pub categories: Option<Vec<String>>,
+    pub generic_name: Option<String>,
+    pub startup_notify: Option<bool>,
+    pub startup_wm_class: Option<String>,
+    pub icon: Option<String>,
+    pub metainfo: Option<String>,
+}
+
+impl DebMakeConfig {
+    fn load() -> Result<Self, PackageError> {
+        Ok(
+            load_make_config(Path::new("linux/packaging/deb/make_config.yaml"))?
+                .unwrap_or_default(),
+        )
+    }
+
+    /// Renders the `DEBIAN/control` file, mirroring Dart's `toJson()['CONTROL']`.
+    fn control_file(&self, config: &PackageConfig) -> String {
+        let meta = load_pubspec_meta();
+        let join = |v: &Option<Vec<String>>| -> Option<String> {
+            v.as_ref().filter(|v| !v.is_empty()).map(|v| v.join(", "))
+        };
+
+        let entries: Vec<(&str, Option<String>)> = vec![
+            ("Maintainer", self.maintainer.as_ref().map(Person::formatted)),
+            (
+                "Package",
+                Some(
+                    self.package_name
+                        .clone()
+                        .unwrap_or_else(|| config.app_binary_name.clone()),
+                ),
+            ),
+            ("Version", Some(config.app_version.clone())),
+            (
+                "Section",
+                Some(self.section.clone().unwrap_or_else(|| "x11".to_string())),
+            ),
+            (
+                "Priority",
+                Some(
+                    self.priority
+                        .clone()
+                        .unwrap_or_else(|| "optional".to_string()),
+                ),
+            ),
+            ("Architecture", Some(deb_architecture().to_string())),
+            (
+                "Essential",
+                self.essential
+                    .map(|e| (if e { "yes" } else { "no" }).to_string()),
+            ),
+            ("Installed-Size", self.installed_size.map(|s| s.to_string())),
+            (
+                "Description",
+                Some(meta.description.unwrap_or_else(|| config.app_name.clone())),
+            ),
+            ("Homepage", meta.homepage),
+            ("Depends", join(&self.dependencies)),
+            ("Build-Depends-Indep", join(&self.build_dependencies_indep)),
+            ("Build-Depends", join(&self.build_dependencies)),
+            ("Pre-Depends", join(&self.pre_dependencies)),
+            ("Recommends", join(&self.recommended_dependencies)),
+            ("Suggests", join(&self.suggested_dependencies)),
+            ("Enhances", join(&self.enhances)),
+            ("Breaks", join(&self.breaks)),
+            ("Conflicts", join(&self.conflicts)),
+            ("Provides", join(&self.provides)),
+            ("Replaces", join(&self.replaces)),
+            (
+                "Uploaders",
+                self.co_authors.as_ref().filter(|v| !v.is_empty()).map(|v| {
+                    v.iter()
+                        .map(Person::formatted)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                }),
+            ),
+        ];
+
+        let mut out = String::new();
+        for (key, value) in entries {
+            if let Some(value) = value {
+                out.push_str(&format!("{}: {}\n", key, value));
+            }
+        }
+        out
+    }
+
+    /// Renders the desktop entry, mirroring Dart's `toJson()['DESKTOP']`.
+    fn desktop_file(&self, config: &PackageConfig) -> String {
+        let binary_name = &config.app_binary_name;
+        render_desktop_entry(&[
+            ("Type", Some("Application".to_string())),
+            (
+                "Name",
+                Some(
+                    self.display_name
+                        .clone()
+                        .unwrap_or_else(|| config.app_name.clone()),
+                ),
+            ),
+            ("GenericName", self.generic_name.clone()),
+            ("Icon", Some(binary_name.clone())),
+            ("Exec", Some(format!("{} %U", binary_name))),
+            ("Actions", desktop_list(&self.actions)),
+            ("MimeType", desktop_list(&self.supported_mime_type)),
+            ("Categories", desktop_list(&self.categories)),
+            ("Keywords", desktop_list(&self.keywords)),
+            (
+                "StartupNotify",
+                Some(self.startup_notify.unwrap_or(true).to_string()),
+            ),
+            ("StartupWMClass", self.startup_wm_class.clone()),
+        ])
+    }
+
+    /// Post-install script, always prefixed with the `/usr/bin` symlink setup
+    /// (mirrors Dart's `postinstallScripts` getter).
+    fn postinst(&self, binary_name: &str) -> String {
+        let mut lines = vec![
+            "#!/usr/bin/env sh".to_string(),
+            format!("ln -s /opt/{n}/{n} /usr/bin/{n}", n = binary_name),
+            format!("chmod +x /usr/bin/{}", binary_name),
+        ];
+        lines.extend(self.postinstall_scripts.clone().unwrap_or_default());
+        lines.push("exit 0".to_string());
+        lines.join("\n")
+    }
+
+    /// Post-uninstall script (mirrors Dart's `postuninstallScripts` getter).
+    fn postrm(&self, binary_name: &str) -> String {
+        let mut lines = vec![
+            "#!/usr/bin/env sh".to_string(),
+            format!("rm /usr/bin/{}", binary_name),
+        ];
+        lines.extend(self.postuninstall_scripts.clone().unwrap_or_default());
+        lines.push("exit 0".to_string());
+        lines.join("\n")
+    }
+}
 
 fn run(cmd: &mut Command) -> Result<(), PackageError> {
     let out = cmd.output().map_err(|e| {
@@ -50,6 +229,7 @@ impl AppPackager for LinuxDebPackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
+        let make_config = DebMakeConfig::load()?;
         let pkg_dir = config.packaging_dir();
         let binary_name = &config.app_binary_name;
 
@@ -61,44 +241,36 @@ impl AppPackager for LinuxDebPackager {
         std::fs::create_dir_all(&share_app_dir)?;
         std::fs::create_dir_all(&applications_dir)?;
 
+        // Install the configured icon and metainfo (when provided)
+        if let Some(icon) = &make_config.icon {
+            install_hicolor_icons(icon, &pkg_dir, binary_name)?;
+        }
+        if let Some(metainfo) = &make_config.metainfo {
+            install_metainfo(metainfo, &pkg_dir, binary_name)?;
+        }
+
         // Copy the flutter build output into /opt/{binary_name}/
         copy_dir_contents(&config.build_output_dir, &share_app_dir)?;
 
-        // Write DEBIAN/control (minimal placeholder; real deployments supply a
-        // make_config.yaml via `DebPackageConfig`; keep compatible with Dart output)
-        let control = format!(
-            "Package: {}\nVersion: {}\nArchitecture: amd64\nMaintainer: unknown\nDescription: {}\n",
-            binary_name, config.app_version, config.app_name,
-        );
-        std::fs::write(debian_dir.join("control"), &control)?;
+        // DEBIAN/control
+        std::fs::write(
+            debian_dir.join("control"),
+            make_config.control_file(config),
+        )?;
 
-        // Write DEBIAN/postinst
-        let postinst = format!(
-            "#!/usr/bin/env sh\nln -s /opt/{n}/{n} /usr/bin/{n}\nchmod +x /usr/bin/{n}\nexit 0\n",
-            n = binary_name,
-        );
+        // DEBIAN/postinst + DEBIAN/postrm
         let postinst_path = debian_dir.join("postinst");
-        std::fs::write(&postinst_path, &postinst)?;
+        std::fs::write(&postinst_path, make_config.postinst(binary_name))?;
         run(Command::new("chmod").args(["+x", &postinst_path.display().to_string()]))?;
 
-        // Write DEBIAN/postrm
-        let postrm = format!(
-            "#!/usr/bin/env sh\nrm /usr/bin/{n}\nexit 0\n",
-            n = binary_name,
-        );
         let postrm_path = debian_dir.join("postrm");
-        std::fs::write(&postrm_path, &postrm)?;
+        std::fs::write(&postrm_path, make_config.postrm(binary_name))?;
         run(Command::new("chmod").args(["+x", &postrm_path.display().to_string()]))?;
 
-        // Write usr/share/applications/{binary_name}.desktop
-        let desktop = format!(
-            "[Desktop Entry]\nType=Application\nName={name}\nExec={bin} %U\nIcon={bin}\n",
-            name = config.app_name,
-            bin = binary_name,
-        );
+        // usr/share/applications/{binary_name}.desktop
         std::fs::write(
             applications_dir.join(format!("{}.desktop", binary_name)),
-            &desktop,
+            make_config.desktop_file(config),
         )?;
 
         let output_file = config.output_file();
@@ -113,5 +285,118 @@ impl AppPackager for LinuxDebPackager {
         Ok(PackageResult {
             artifacts: vec![output_file],
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_config() -> PackageConfig {
+        PackageConfig {
+            app_name: "hola_amigos".into(),
+            app_binary_name: "hola_amigos".into(),
+            app_version: "1.2.3+4".into(),
+            build_mode: "release".into(),
+            platform: Platform::Linux,
+            flavor: None,
+            channel: None,
+            artifact_name: None,
+            package_format: "deb".into(),
+            is_installer: false,
+            build_output_dir: PathBuf::new(),
+            build_output_files: vec![],
+            output_dir: PathBuf::new(),
+        }
+    }
+
+    fn full_make_config() -> DebMakeConfig {
+        serde_yaml::from_str(
+            r#"
+display_name: Hola Amigos
+package_name: hola-amigos
+maintainer:
+  name: Gamer Boy 69
+  email: rickastley@gmail.lol
+co_authors:
+  - name: Mir Jafar
+    email: contributor@gmail.com
+priority: optional
+section: x11
+installed_size: 24400
+dependencies:
+  - libkeybinder-3.0-0 (>= 0.3.2)
+essential: false
+postinstall_scripts:
+  - echo Installed
+postuninstall_scripts:
+  - echo Removed
+keywords:
+  - Hello
+  - World
+generic_name: Hobby Application
+supported_mime_type:
+  - audio/mpeg
+actions:
+  - Gallery
+categories:
+  - Music
+  - Media
+startup_notify: true
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn control_file_contains_all_fields() {
+        let control = full_make_config().control_file(&test_config());
+        assert!(control.contains("Maintainer: Gamer Boy 69 <rickastley@gmail.lol>"));
+        assert!(control.contains("Package: hola-amigos"));
+        assert!(control.contains("Version: 1.2.3+4"));
+        assert!(control.contains("Section: x11"));
+        assert!(control.contains("Priority: optional"));
+        assert!(control.contains("Essential: no"));
+        assert!(control.contains("Installed-Size: 24400"));
+        assert!(control.contains("Depends: libkeybinder-3.0-0 (>= 0.3.2)"));
+        assert!(control.contains("Uploaders: Mir Jafar <contributor@gmail.com>"));
+    }
+
+    #[test]
+    fn desktop_file_contains_lists() {
+        let desktop = full_make_config().desktop_file(&test_config());
+        assert!(desktop.contains("Name=Hola Amigos"));
+        assert!(desktop.contains("GenericName=Hobby Application"));
+        assert!(desktop.contains("Exec=hola_amigos %U"));
+        assert!(desktop.contains("Actions=Gallery;"));
+        assert!(desktop.contains("MimeType=audio/mpeg;"));
+        assert!(desktop.contains("Categories=Music;Media;"));
+        assert!(desktop.contains("Keywords=Hello;World;"));
+        assert!(desktop.contains("StartupNotify=true"));
+    }
+
+    #[test]
+    fn scripts_include_symlink_setup_and_custom_lines() {
+        let mc = full_make_config();
+        let postinst = mc.postinst("hola_amigos");
+        assert!(postinst.contains("ln -s /opt/hola_amigos/hola_amigos /usr/bin/hola_amigos"));
+        assert!(postinst.contains("echo Installed"));
+        assert!(postinst.ends_with("exit 0"));
+        let postrm = mc.postrm("hola_amigos");
+        assert!(postrm.contains("rm /usr/bin/hola_amigos"));
+        assert!(postrm.contains("echo Removed"));
+    }
+
+    #[test]
+    fn defaults_without_make_config() {
+        let mc = DebMakeConfig::default();
+        let control = mc.control_file(&test_config());
+        assert!(control.contains("Package: hola_amigos"));
+        assert!(control.contains("Section: x11"));
+        assert!(control.contains("Priority: optional"));
+        let desktop = mc.desktop_file(&test_config());
+        assert!(desktop.contains("Name=hola_amigos"));
+        assert!(desktop.contains("StartupNotify=true"));
     }
 }

--- a/crates/app_packager/src/linux/direct.rs
+++ b/crates/app_packager/src/linux/direct.rs
@@ -33,7 +33,9 @@ impl AppPackager for LinuxDirectPackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
-        let dst = config.version_output_dir().join(&config.app_name);
+        // Mirrors Dart: the destination directory uses the rendered artifact
+        // name (no extension for direct output).
+        let dst = config.output_file();
         copy_dir(&config.build_output_dir, &dst)?;
         Ok(PackageResult {
             artifacts: vec![dst],

--- a/crates/app_packager/src/linux/mod.rs
+++ b/crates/app_packager/src/linux/mod.rs
@@ -1,4 +1,5 @@
 pub mod appimage;
+pub mod common;
 pub mod deb;
 pub mod direct;
 pub mod pacman;

--- a/crates/app_packager/src/linux/pacman.rs
+++ b/crates/app_packager/src/linux/pacman.rs
@@ -1,12 +1,179 @@
+use std::path::Path;
 use std::process::Command;
 
 use fastforge_core::{AppPackager, PackageConfig, PackageError, PackageResult, Platform};
+use serde::Deserialize;
+
+use super::common::{
+    Person, desktop_list, install_hicolor_icons, install_metainfo, load_make_config,
+    load_pubspec_meta, render_desktop_entry, uname_machine,
+};
 
 /// Builds a pacman `.pkg.tar.xz` using `bsdtar` and `xz`, mirroring
 /// Dart's `AppPackageMakerPacman`.
 ///
+/// Reads `linux/packaging/pacman/make_config.yaml` when present (same schema
+/// as Dart's `MakePacmanConfig`); falls back to sensible defaults otherwise.
+///
 /// Requires `bsdtar` (libarchive) and `xz` to be on `$PATH`.
 pub struct LinuxPacmanPackager;
+
+/// Schema of `linux/packaging/pacman/make_config.yaml`, mirroring Dart's
+/// `MakePacmanConfig.fromJson`.
+#[derive(Debug, Default, Deserialize)]
+pub struct PacmanMakeConfig {
+    pub display_name: Option<String>,
+    pub package_name: Option<String>,
+    pub maintainer: Option<Person>,
+    pub installed_size: Option<i64>,
+    pub licenses: Option<Vec<String>>,
+    pub groups: Option<Vec<String>>,
+    pub options: Option<Vec<String>>,
+    pub dependencies: Option<Vec<String>>,
+    pub optional_dependencies: Option<Vec<String>>,
+    pub conflicts: Option<Vec<String>>,
+    pub replaces: Option<Vec<String>>,
+    pub provides: Option<Vec<String>>,
+    pub postinstall_scripts: Option<Vec<String>>,
+    pub postupgrade_scripts: Option<Vec<String>>,
+    pub postuninstall_scripts: Option<Vec<String>>,
+    pub keywords: Option<Vec<String>>,
+    pub supported_mime_type: Option<Vec<String>>,
+    pub actions: Option<Vec<String>>,
+    pub categories: Option<Vec<String>>,
+    pub generic_name: Option<String>,
+    pub startup_notify: Option<bool>,
+    pub icon: Option<String>,
+    pub metainfo: Option<String>,
+}
+
+/// pacman architecture from `uname -m`.
+fn pacman_architecture() -> String {
+    if uname_machine() == "aarch64" {
+        "aarch64".to_string()
+    } else {
+        "x86_64".to_string()
+    }
+}
+
+impl PacmanMakeConfig {
+    fn load() -> Result<Self, PackageError> {
+        Ok(
+            load_make_config(Path::new("linux/packaging/pacman/make_config.yaml"))?
+                .unwrap_or_default(),
+        )
+    }
+
+    /// Renders `.PKGINFO`, mirroring Dart's `toFilesString()['PKGINFO']`.
+    fn pkginfo_file(&self, config: &PackageConfig) -> String {
+        let meta = load_pubspec_meta();
+        let paren = |v: &Option<Vec<String>>| -> Option<String> {
+            v.as_ref()
+                .filter(|v| !v.is_empty())
+                .map(|v| format!("({})", v.join(", ")))
+        };
+        let licenses = self
+            .licenses
+            .clone()
+            .unwrap_or_else(|| vec!["unknown".to_string()]);
+        let groups = self
+            .groups
+            .clone()
+            .unwrap_or_else(|| vec!["default".to_string()]);
+
+        let entries: Vec<(&str, Option<String>)> = vec![
+            (
+                "pkgname",
+                Some(
+                    self.package_name
+                        .clone()
+                        .unwrap_or_else(|| config.app_binary_name.clone()),
+                ),
+            ),
+            ("pkgver", Some(config.app_version.clone())),
+            (
+                "pkgdesc",
+                Some(meta.description.unwrap_or_else(|| config.app_name.clone())),
+            ),
+            ("packager", self.maintainer.as_ref().map(Person::formatted)),
+            ("size", self.installed_size.map(|s| s.to_string())),
+            ("license", Some(format!("({})", licenses.join(", ")))),
+            ("groups", Some(format!("({})", groups.join(", ")))),
+            ("arch", Some(format!("({})", pacman_architecture()))),
+            ("url", meta.homepage),
+            ("options", paren(&self.options)),
+            ("depends", paren(&self.dependencies)),
+            ("optdepends", paren(&self.optional_dependencies)),
+            ("conflicts", paren(&self.conflicts)),
+            ("replaces", paren(&self.replaces)),
+            ("provides", paren(&self.provides)),
+        ];
+
+        let mut out = String::new();
+        for (key, value) in entries {
+            if let Some(value) = value {
+                out.push_str(&format!("{}={}\n", key, value));
+            }
+        }
+        out
+    }
+
+    /// Renders `.INSTALL`, mirroring Dart's `toFilesString()['INSTALL']`.
+    fn install_file(&self, binary_name: &str) -> String {
+        let mut post_install = vec![
+            format!("ln -s /opt/{n}/{n} /usr/bin/{n}", n = binary_name),
+            format!("chmod +x /usr/bin/{}", binary_name),
+        ];
+        post_install.extend(self.postinstall_scripts.clone().unwrap_or_default());
+
+        let mut post_remove = vec![format!("rm /usr/bin/{}", binary_name)];
+        post_remove.extend(self.postuninstall_scripts.clone().unwrap_or_default());
+
+        let mut sections = vec![format!(
+            "post_install() {{\n\t{}\n}}",
+            post_install.join("\n\t")
+        )];
+        if let Some(upgrade) = self
+            .postupgrade_scripts
+            .as_ref()
+            .filter(|v| !v.is_empty())
+        {
+            sections.push(format!("post_upgrade() {{\n\t{}\n}}", upgrade.join("\n")));
+        }
+        sections.push(format!(
+            "post_remove() {{\n\t{}\n}}",
+            post_remove.join("\n")
+        ));
+        sections.join("\n")
+    }
+
+    /// Renders the desktop entry, mirroring Dart's `toJson()['DESKTOP']`.
+    fn desktop_file(&self, config: &PackageConfig) -> String {
+        let binary_name = &config.app_binary_name;
+        render_desktop_entry(&[
+            ("Type", Some("Application".to_string())),
+            (
+                "Name",
+                Some(
+                    self.display_name
+                        .clone()
+                        .unwrap_or_else(|| config.app_name.clone()),
+                ),
+            ),
+            ("GenericName", self.generic_name.clone()),
+            ("Icon", Some(binary_name.clone())),
+            ("Exec", Some(format!("{} %U", binary_name))),
+            ("Actions", desktop_list(&self.actions)),
+            ("MimeType", desktop_list(&self.supported_mime_type)),
+            ("Categories", desktop_list(&self.categories)),
+            ("Keywords", desktop_list(&self.keywords)),
+            (
+                "StartupNotify",
+                Some(self.startup_notify.unwrap_or(false).to_string()),
+            ),
+        ])
+    }
+}
 
 fn run(cmd: &mut Command) -> Result<(), PackageError> {
     let out = cmd.output().map_err(|e| {
@@ -40,6 +207,7 @@ impl AppPackager for LinuxPacmanPackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
+        let make_config = PacmanMakeConfig::load()?;
         let pkg_dir = config.packaging_dir();
         let binary_name = &config.app_binary_name;
 
@@ -49,6 +217,14 @@ impl AppPackager for LinuxPacmanPackager {
         std::fs::create_dir_all(&share_app_dir)?;
         std::fs::create_dir_all(&applications_dir)?;
 
+        // Install the configured icon and metainfo (when provided)
+        if let Some(icon) = &make_config.icon {
+            install_hicolor_icons(icon, &pkg_dir, binary_name)?;
+        }
+        if let Some(metainfo) = &make_config.metainfo {
+            install_metainfo(metainfo, &pkg_dir, binary_name)?;
+        }
+
         // Copy the flutter build output into /opt/{binary_name}/
         run(Command::new("cp").args([
             "-fr",
@@ -56,31 +232,18 @@ impl AppPackager for LinuxPacmanPackager {
             &share_app_dir.display().to_string(),
         ]))?;
 
-        // Write .PKGINFO
-        let pkginfo = format!(
-            "pkgname = {name}\npkgver = {ver}-1\npkgdesc = {name}\narch = x86_64\nurl = \nsize = 0\n",
-            name = binary_name,
-            ver = config.app_version.split('+').next().unwrap_or("0.0.1"),
-        );
-        std::fs::write(pkg_dir.join(".PKGINFO"), &pkginfo)?;
-
-        // Write .INSTALL
-        let install = format!(
-            "post_install() {{\n  ln -s /opt/{n}/{n} /usr/bin/{n}\n  chmod +x /usr/bin/{n}\n}}\n\
-             post_remove() {{\n  rm -f /usr/bin/{n}\n}}\n",
-            n = binary_name,
-        );
-        std::fs::write(pkg_dir.join(".INSTALL"), &install)?;
-
-        // Write .desktop entry
-        let desktop = format!(
-            "[Desktop Entry]\nType=Application\nName={name}\nExec={bin} %U\nIcon={bin}\n",
-            name = config.app_name,
-            bin = binary_name,
-        );
+        // Write .PKGINFO, .INSTALL, .desktop
+        std::fs::write(
+            pkg_dir.join(".PKGINFO"),
+            make_config.pkginfo_file(config),
+        )?;
+        std::fs::write(
+            pkg_dir.join(".INSTALL"),
+            make_config.install_file(binary_name),
+        )?;
         std::fs::write(
             applications_dir.join(format!("{}.desktop", binary_name)),
-            &desktop,
+            make_config.desktop_file(config),
         )?;
 
         // Create .MTREE metadata
@@ -93,8 +256,8 @@ impl AppPackager for LinuxPacmanPackager {
                 "--options=!all,use-set,type,uid,gid,mode,time,size,md5,sha256,link",
                 ".PKGINFO",
                 ".INSTALL",
-                "opt",
                 "usr",
+                "opt",
             ])
             .env("LANG", "C"))?;
 
@@ -102,7 +265,7 @@ impl AppPackager for LinuxPacmanPackager {
         run(Command::new("bsdtar")
             .current_dir(&pkg_dir)
             .args([
-                "-cf", "temptar", ".MTREE", ".INSTALL", ".PKGINFO", "opt", "usr",
+                "-cf", "temptar", ".MTREE", ".INSTALL", ".PKGINFO", "usr", "opt",
             ])
             .env("LANG", "C"))?;
 
@@ -119,5 +282,109 @@ impl AppPackager for LinuxPacmanPackager {
         Ok(PackageResult {
             artifacts: vec![output_file],
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_config() -> PackageConfig {
+        PackageConfig {
+            app_name: "hola_amigos".into(),
+            app_binary_name: "hola_amigos".into(),
+            app_version: "1.2.3+4".into(),
+            build_mode: "release".into(),
+            platform: Platform::Linux,
+            flavor: None,
+            channel: None,
+            artifact_name: None,
+            package_format: "pacman".into(),
+            is_installer: false,
+            build_output_dir: PathBuf::new(),
+            build_output_files: vec![],
+            output_dir: PathBuf::new(),
+        }
+    }
+
+    fn full_make_config() -> PacmanMakeConfig {
+        serde_yaml::from_str(
+            r#"
+display_name: Hola Amigos
+package_name: hola-amigos
+maintainer:
+  name: Gamer Boy 69
+  email: rickastley@gmail.lol
+installed_size: 24400
+licenses:
+  - MIT
+dependencies:
+  - mysupercooldep
+optional_dependencies:
+  - iamalwaysoptional
+options:
+  - zipman
+conflicts:
+  - libwhatsup
+replaces:
+  - yourdep
+provides:
+  - libx11
+postinstall_scripts:
+  - echo Installed
+postupgrade_scripts:
+  - echo Upgraded
+postuninstall_scripts:
+  - echo Removed
+categories:
+  - Music
+startup_notify: true
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn pkginfo_contains_configured_fields() {
+        let pkginfo = full_make_config().pkginfo_file(&test_config());
+        assert!(pkginfo.contains("pkgname=hola-amigos"));
+        assert!(pkginfo.contains("pkgver=1.2.3+4"));
+        assert!(pkginfo.contains("packager=Gamer Boy 69 <rickastley@gmail.lol>"));
+        assert!(pkginfo.contains("size=24400"));
+        assert!(pkginfo.contains("license=(MIT)"));
+        assert!(pkginfo.contains("groups=(default)"));
+        assert!(pkginfo.contains("options=(zipman)"));
+        assert!(pkginfo.contains("depends=(mysupercooldep)"));
+        assert!(pkginfo.contains("optdepends=(iamalwaysoptional)"));
+        assert!(pkginfo.contains("conflicts=(libwhatsup)"));
+        assert!(pkginfo.contains("replaces=(yourdep)"));
+        assert!(pkginfo.contains("provides=(libx11)"));
+    }
+
+    #[test]
+    fn install_file_sections() {
+        let install = full_make_config().install_file("hola_amigos");
+        assert!(install.contains("post_install() {"));
+        assert!(install.contains("ln -s /opt/hola_amigos/hola_amigos /usr/bin/hola_amigos"));
+        assert!(install.contains("echo Installed"));
+        assert!(install.contains("post_upgrade() {"));
+        assert!(install.contains("echo Upgraded"));
+        assert!(install.contains("post_remove() {"));
+        assert!(install.contains("rm /usr/bin/hola_amigos"));
+        assert!(install.contains("echo Removed"));
+    }
+
+    #[test]
+    fn install_file_omits_empty_upgrade_section() {
+        let install = PacmanMakeConfig::default().install_file("demo");
+        assert!(!install.contains("post_upgrade"));
+    }
+
+    #[test]
+    fn desktop_defaults() {
+        let desktop = PacmanMakeConfig::default().desktop_file(&test_config());
+        assert!(desktop.contains("Name=hola_amigos"));
+        assert!(desktop.contains("StartupNotify=false"));
     }
 }

--- a/crates/app_packager/src/linux/rpm.rs
+++ b/crates/app_packager/src/linux/rpm.rs
@@ -1,11 +1,258 @@
+use std::path::Path;
 use std::process::Command;
 
 use fastforge_core::{AppPackager, PackageConfig, PackageError, PackageResult, Platform};
+use serde::Deserialize;
+
+use super::common::{
+    desktop_list, load_make_config, load_pubspec_meta, render_desktop_entry, uname_machine,
+};
 
 /// Builds an RPM package using `rpmbuild`, mirroring Dart's `AppPackageMakerRPM`.
 ///
-/// Requires `rpmbuild` (from the `rpm-build` package) and optionally `patchelf`.
+/// Reads `linux/packaging/rpm/make_config.yaml` when present (same schema as
+/// Dart's `MakeRPMConfig`); falls back to sensible defaults otherwise.
+///
+/// Requires `rpmbuild` (from the `rpm-build` package) and `patchelf`.
 pub struct LinuxRpmPackager;
+
+/// Schema of `linux/packaging/rpm/make_config.yaml`, mirroring Dart's
+/// `MakeRPMConfig.fromJson`.
+#[derive(Debug, Default, Deserialize)]
+pub struct RpmMakeConfig {
+    // Desktop file
+    pub display_name: Option<String>,
+    pub package_name: Option<String>,
+    pub startup_notify: Option<bool>,
+    pub actions: Option<Vec<String>>,
+    pub categories: Option<Vec<String>>,
+    pub generic_name: Option<String>,
+    pub icon: Option<String>,
+    pub metainfo: Option<String>,
+    pub keywords: Option<Vec<String>>,
+    pub supported_mime_type: Option<Vec<String>>,
+
+    // Spec preamble
+    pub summary: Option<String>,
+    pub group: Option<String>,
+    pub vendor: Option<String>,
+    pub packager: Option<String>,
+    #[serde(alias = "packagerEmail")]
+    pub packager_email: Option<String>,
+    pub license: Option<String>,
+    pub url: Option<String>,
+    pub build_arch: Option<String>,
+    pub requires: Option<Vec<String>>,
+    pub build_requires: Option<Vec<String>>,
+
+    // Spec body
+    pub description: Option<String>,
+    pub postun: Option<String>,
+    pub postinstall_scripts: Option<Vec<String>>,
+    pub postuninstall_scripts: Option<Vec<String>>,
+    pub spec_macros: Option<Vec<String>>,
+}
+
+/// RPM architecture from `uname -m`, mirroring Dart's `_getArchitecture`.
+fn rpm_architecture() -> String {
+    if uname_machine() == "aarch64" {
+        "aarch64".to_string()
+    } else {
+        "x86_64".to_string()
+    }
+}
+
+/// Sanitizes an ELF RPATH, replacing absolute entries with `$ORIGIN` and
+/// de-duplicating, mirroring Dart's `sanitizeRpmRpath`.
+/// This prevents rpmbuild QA failures for build-directory RPATHs
+/// (https://github.com/flutter/flutter/issues/65400).
+pub fn sanitize_rpm_rpath(rpath: &str) -> String {
+    let mut sanitized: Vec<String> = Vec::new();
+    for entry in rpath.split(':') {
+        let value = if entry.starts_with('/') {
+            "$ORIGIN".to_string()
+        } else {
+            entry.to_string()
+        };
+        if !sanitized.contains(&value) {
+            sanitized.push(value);
+        }
+    }
+    sanitized.join(":")
+}
+
+impl RpmMakeConfig {
+    fn load() -> Result<Self, PackageError> {
+        Ok(
+            load_make_config(Path::new("linux/packaging/rpm/make_config.yaml"))?
+                .unwrap_or_default(),
+        )
+    }
+
+    fn rpm_name(&self, config: &PackageConfig) -> String {
+        self.package_name
+            .clone()
+            .unwrap_or_else(|| config.app_name.clone())
+    }
+
+    fn build_arch(&self) -> String {
+        self.build_arch.clone().unwrap_or_else(rpm_architecture)
+    }
+
+    /// Renders the `.spec` file, mirroring Dart's `toFilesString()['SPEC']`.
+    fn spec_file(&self, config: &PackageConfig) -> String {
+        let meta = load_pubspec_meta();
+        let build_number = config.app_version.split('+').nth(1);
+        let description = self
+            .description
+            .clone()
+            .or_else(|| meta.description.clone())
+            .unwrap_or_else(|| config.app_name.clone());
+
+        // Preamble
+        let mut preamble: Vec<(&str, Option<String>)> = vec![
+            ("Name", Some(self.rpm_name(config))),
+            ("Version", Some(config.app_version.clone())),
+            (
+                "Release",
+                Some(format!("{}%{{?dist}}", build_number.unwrap_or("1"))),
+            ),
+            (
+                "Summary",
+                self.summary
+                    .clone()
+                    .or_else(|| meta.description.clone())
+                    .or_else(|| Some(config.app_name.clone())),
+            ),
+            ("Group", self.group.clone()),
+            ("Vendor", self.vendor.clone()),
+            (
+                "Packager",
+                match (&self.packager, &self.packager_email) {
+                    (Some(p), Some(e)) => Some(format!("{} <{}>", p, e)),
+                    (p, None) => p.clone(),
+                    (None, Some(e)) => Some(format!(" <{}>", e)),
+                },
+            ),
+            ("License", self.license.clone()),
+            ("URL", self.url.clone()),
+        ];
+        if let Some(requires) = self.requires.as_ref().filter(|v| !v.is_empty()) {
+            preamble.push(("Requires", Some(requires.join(", "))));
+        }
+        if let Some(build_requires) = self.build_requires.as_ref().filter(|v| !v.is_empty()) {
+            preamble.push(("BuildRequires", Some(build_requires.join(", "))));
+        }
+        preamble.push(("BuildArch", Some(self.build_arch())));
+
+        let preamble_str = preamble
+            .into_iter()
+            .filter_map(|(k, v)| v.map(|v| format!("{}: {}", k, v)))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Body
+        let app_name = &config.app_name;
+        let binary_name = &config.app_binary_name;
+        let install_script = [
+            "mkdir -p %{buildroot}%{_bindir}".to_string(),
+            "mkdir -p %{buildroot}%{_datadir}/%{name}".to_string(),
+            "mkdir -p %{buildroot}%{_datadir}/applications".to_string(),
+            "mkdir -p %{buildroot}%{_datadir}/metainfo".to_string(),
+            "mkdir -p %{buildroot}%{_datadir}/pixmaps".to_string(),
+            format!("cp -r {}/* %{{buildroot}}%{{_datadir}}/%{{name}}", app_name),
+            format!(
+                "ln -s %{{_datadir}}/%{{name}}/{} %{{buildroot}}%{{_bindir}}/%{{name}}",
+                binary_name
+            ),
+            format!(
+                "cp -r {}.desktop %{{buildroot}}%{{_datadir}}/applications/%{{name}}.desktop",
+                binary_name
+            ),
+            format!(
+                "cp -r {}.png %{{buildroot}}%{{_datadir}}/pixmaps/%{{name}}.png",
+                binary_name
+            ),
+            format!(
+                "cp -r {}*.xml %{{buildroot}}%{{_datadir}}/metainfo/%{{name}}.appdata.xml || :",
+                binary_name
+            ),
+        ]
+        .join("\n");
+
+        // %post always refreshes the MIME database, then runs any custom
+        // scripts (mirrors Dart's postScripts/postunScripts getters).
+        let mut post_scripts =
+            vec!["update-mime-database %{_datadir}/mime &> /dev/null || :".to_string()];
+        post_scripts.extend(self.postinstall_scripts.clone().unwrap_or_default());
+
+        let mut postun_scripts =
+            vec!["update-mime-database %{_datadir}/mime &> /dev/null || :".to_string()];
+        if let Some(postun) = &self.postun {
+            postun_scripts.push(postun.clone());
+        }
+        postun_scripts.extend(self.postuninstall_scripts.clone().unwrap_or_default());
+
+        let files_section = [
+            "%{_bindir}/%{name}",
+            "%{_datadir}/%{name}",
+            "%{_datadir}/applications/%{name}.desktop",
+            "%{_datadir}/metainfo",
+        ]
+        .join("\n");
+
+        let body = [
+            format!("%description\n{}\n", description),
+            format!("%install\n{}\n", install_script),
+            format!("%post\n{}\n", post_scripts.join("\n")),
+            format!("%postun\n{}\n", postun_scripts.join("\n")),
+            format!("%files\n{}\n", files_section),
+        ]
+        .join("\n");
+
+        let inline_body = [
+            "%defattr(-,root,root)\n",
+            "%attr(4755, root, root) %{_datadir}/pixmaps/%{name}.png\n",
+        ]
+        .join("\n");
+
+        let macros = self
+            .spec_macros
+            .as_ref()
+            .filter(|v| !v.is_empty())
+            .map(|v| format!("{}\n\n", v.join("\n")))
+            .unwrap_or_default();
+
+        format!("{}{}\n\n{}\n\n{}", macros, preamble_str, body, inline_body)
+    }
+
+    /// Renders the desktop entry, mirroring Dart's `toJson()['DESKTOP']`.
+    fn desktop_file(&self, config: &PackageConfig) -> String {
+        let rpm_name = self.rpm_name(config);
+        render_desktop_entry(&[
+            ("Type", Some("Application".to_string())),
+            (
+                "Name",
+                Some(
+                    self.display_name
+                        .clone()
+                        .unwrap_or_else(|| config.app_name.clone()),
+                ),
+            ),
+            ("GenericName", self.generic_name.clone()),
+            ("Icon", Some(rpm_name.clone())),
+            ("Exec", Some(format!("{} %U", rpm_name))),
+            ("Actions", desktop_list(&self.actions)),
+            ("MimeType", desktop_list(&self.supported_mime_type)),
+            ("Categories", desktop_list(&self.categories)),
+            ("Keywords", desktop_list(&self.keywords)),
+            (
+                "StartupNotify",
+                Some(self.startup_notify.unwrap_or(true).to_string()),
+            ),
+        ])
+    }
+}
 
 fn run(cmd: &mut Command) -> Result<(), PackageError> {
     let out = cmd.output().map_err(|e| {
@@ -16,6 +263,39 @@ fn run(cmd: &mut Command) -> Result<(), PackageError> {
             command: cmd.get_program().to_string_lossy().into(),
             stderr: String::from_utf8_lossy(&out.stderr).into(),
         });
+    }
+    Ok(())
+}
+
+/// Runs `patchelf --print-rpath` / `--set-rpath` on every `lib/*.so` in the
+/// bundle, replacing absolute RPATH entries with `$ORIGIN` (mirrors the Dart
+/// maker's RPATH fix for https://github.com/flutter/flutter/issues/65400).
+fn sanitize_bundle_rpaths(build_root: &Path) -> Result<(), PackageError> {
+    let lib_dir = build_root.join("lib");
+    let Ok(entries) = std::fs::read_dir(&lib_dir) else {
+        return Ok(());
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() || path.extension().is_none_or(|e| e != "so") {
+            continue;
+        }
+        let out = Command::new("patchelf")
+            .args(["--print-rpath", &path.display().to_string()])
+            .output()
+            .map_err(|e| PackageError::MissingTool(format!("patchelf: {}", e)))?;
+        if !out.status.success() {
+            continue;
+        }
+        let rpath = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        let sanitized = sanitize_rpm_rpath(&rpath);
+        if sanitized != rpath {
+            run(Command::new("patchelf").args([
+                "--set-rpath",
+                &sanitized,
+                &path.display().to_string(),
+            ]))?;
+        }
     }
     Ok(())
 }
@@ -39,6 +319,7 @@ impl AppPackager for LinuxRpmPackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
+        let make_config = RpmMakeConfig::load()?;
         let pkg_dir = config.packaging_dir();
         let binary_name = &config.app_binary_name;
         let app_name = &config.app_name;
@@ -50,7 +331,8 @@ impl AppPackager for LinuxRpmPackager {
         }
 
         // Copy app files into BUILD/{app_name}/
-        let build_root = rpmbuild_dir.join("BUILD").join(app_name);
+        let build_dir = rpmbuild_dir.join("BUILD");
+        let build_root = build_dir.join(app_name);
         std::fs::create_dir_all(&build_root)?;
         run(Command::new("cp").args([
             "-fr",
@@ -58,48 +340,63 @@ impl AppPackager for LinuxRpmPackager {
             &build_root.display().to_string(),
         ]))?;
 
-        // Write {app_name}.desktop into BUILD/
-        let desktop = format!(
-            "[Desktop Entry]\nType=Application\nName={name}\nExec=/opt/{bin}/{bin} %U\nIcon={bin}\n",
-            name = config.app_name,
-            bin = binary_name,
-        );
-        std::fs::write(
-            rpmbuild_dir
-                .join("BUILD")
-                .join(format!("{}.desktop", app_name)),
-            &desktop,
-        )?;
+        // Fix lib_*_plugin.so RPATHs pointing at the build directory
+        sanitize_bundle_rpaths(&build_root)?;
 
-        // Minimal .spec file
-        let arch = "x86_64";
-        let spec = format!(
-            "%define _rpmdir %{{_topdir}}/RPMS\n\
-             Name: {name}\n\
-             Version: {ver}\n\
-             Release: 1\n\
-             Summary: {name}\n\
-             License: Unknown\n\
-             BuildArch: {arch}\n\n\
-             %description\n{name}\n\n\
-             %install\n\
-             mkdir -p %{{buildroot}}/opt/{bin}\n\
-             cp -r %{{_builddir}}/{name}/. %{{buildroot}}/opt/{bin}/\n\
-             mkdir -p %{{buildroot}}/usr/share/applications\n\
-             cp %{{_builddir}}/{name}.desktop %{{buildroot}}/usr/share/applications/\n\n\
-             %files\n\
-             /opt/{bin}\n\
-             /usr/share/applications/{name}.desktop\n",
-            name = app_name,
-            ver = config.app_version.split('+').next().unwrap_or("0.0.1"),
-            arch = arch,
-            bin = binary_name,
-        );
+        // Copy the configured icon into BUILD/<binary><ext>
+        if let Some(icon) = &make_config.icon {
+            let icon_path = Path::new(icon);
+            if !icon_path.exists() {
+                return Err(PackageError::NotFound(format!(
+                    "provided icon {} path wasn't found",
+                    icon
+                )));
+            }
+            let ext = icon_path
+                .extension()
+                .map(|e| format!(".{}", e.to_string_lossy()))
+                .unwrap_or_default();
+            std::fs::copy(icon_path, build_dir.join(format!("{}{}", binary_name, ext)))?;
+        }
+
+        // Copy the configured metainfo into BUILD/<binary><ext2>
+        if let Some(metainfo) = &make_config.metainfo {
+            let metainfo_path = Path::new(metainfo);
+            if !metainfo_path.exists() {
+                return Err(PackageError::NotFound(format!(
+                    "Metainfo {} path doesn't exist",
+                    metainfo
+                )));
+            }
+            let file_name = metainfo_path
+                .file_name()
+                .map(|f| f.to_string_lossy().to_string())
+                .unwrap_or_default();
+            let ext = {
+                let parts: Vec<&str> = file_name.split('.').collect();
+                match parts.len() {
+                    0 | 1 => String::new(),
+                    2 => format!(".{}", parts[1]),
+                    n => format!(".{}.{}", parts[n - 2], parts[n - 1]),
+                }
+            };
+            std::fs::copy(
+                metainfo_path,
+                build_dir.join(format!("{}{}", binary_name, ext)),
+            )?;
+        }
+
+        // Write BUILD/{binary_name}.desktop and SPECS/{binary_name}.spec
+        std::fs::write(
+            build_dir.join(format!("{}.desktop", binary_name)),
+            make_config.desktop_file(config),
+        )?;
         let spec_path = rpmbuild_dir
             .join("SPECS")
-            .join(format!("{}.spec", app_name));
-        std::fs::write(&spec_path, &spec)?;
+            .join(format!("{}.spec", binary_name));
+        std::fs::write(&spec_path, make_config.spec_file(config))?;
 
+        // QA_RPATHS = 0x0001 | 0x0010 tolerates $ORIGIN-style RPATHs
         run(Command::new("rpmbuild")
             .args([
                 "--define",
@@ -107,14 +404,15 @@ impl AppPackager for LinuxRpmPackager {
                 "-bb",
                 &spec_path.display().to_string(),
             ])
-            .env("QA_RPATHS", "17"))?;
+            .env("QA_RPATHS", (0x0001 | 0x0010).to_string()))?;
 
         // Find the produced RPM and copy it to the output file
-        let rpm_dir = rpmbuild_dir.join("RPMS").join(arch);
+        let rpm_dir = rpmbuild_dir.join("RPMS").join(make_config.build_arch());
         let output_file = config.output_file();
         let entries: Vec<_> = std::fs::read_dir(&rpm_dir)
             .map_err(|_| PackageError::NotFound(rpm_dir.display().to_string()))?
             .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_file())
             .collect();
         let first_rpm = entries
             .first()
@@ -125,5 +423,99 @@ impl AppPackager for LinuxRpmPackager {
         Ok(PackageResult {
             artifacts: vec![output_file],
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_config() -> PackageConfig {
+        PackageConfig {
+            app_name: "hola_amigos".into(),
+            app_binary_name: "hola_amigos".into(),
+            app_version: "1.2.3+4".into(),
+            build_mode: "release".into(),
+            platform: Platform::Linux,
+            flavor: None,
+            channel: None,
+            artifact_name: None,
+            package_format: "rpm".into(),
+            is_installer: false,
+            build_output_dir: PathBuf::new(),
+            build_output_files: vec![],
+            output_dir: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn sanitize_rpath_replaces_absolute_and_dedupes() {
+        assert_eq!(
+            sanitize_rpm_rpath("/home/user/build/lib:/opt/x:$ORIGIN"),
+            "$ORIGIN"
+        );
+        assert_eq!(
+            sanitize_rpm_rpath("$ORIGIN/../lib:/home/user/build"),
+            "$ORIGIN/../lib:$ORIGIN"
+        );
+        assert_eq!(sanitize_rpm_rpath(""), "");
+    }
+
+    #[test]
+    fn spec_file_contains_configured_fields() {
+        let mc: RpmMakeConfig = serde_yaml::from_str(
+            r#"
+display_name: Hola Amigos
+package_name: hola-amigos
+summary: An awesome app
+group: Applications/Multimedia
+vendor: ACME
+packager: Gamer Boy 69
+packager_email: rickastley@gmail.lol
+license: MIT
+url: https://example.com
+requires:
+  - libkeybinder
+postinstall_scripts:
+  - echo Installed
+postun: echo Uninstalling
+spec_macros:
+  - "%define _build_id_links none"
+"#,
+        )
+        .unwrap();
+        let spec = mc.spec_file(&test_config());
+        assert!(spec.starts_with("%define _build_id_links none"));
+        assert!(spec.contains("Name: hola-amigos"));
+        assert!(spec.contains("Version: 1.2.3+4"));
+        assert!(spec.contains("Release: 4%{?dist}"));
+        assert!(spec.contains("Summary: An awesome app"));
+        assert!(spec.contains("Packager: Gamer Boy 69 <rickastley@gmail.lol>"));
+        assert!(spec.contains("License: MIT"));
+        assert!(spec.contains("Requires: libkeybinder"));
+        assert!(spec.contains("%post\nupdate-mime-database %{_datadir}/mime &> /dev/null || :\necho Installed"));
+        assert!(spec.contains("echo Uninstalling"));
+        assert!(spec.contains("%attr(4755, root, root)"));
+    }
+
+    #[test]
+    fn spec_defaults_without_make_config() {
+        let mc = RpmMakeConfig::default();
+        let spec = mc.spec_file(&test_config());
+        assert!(spec.contains("Name: hola_amigos"));
+        assert!(spec.contains("Release: 4%{?dist}"));
+        assert!(spec.contains("%description"));
+        assert!(spec.contains("%files"));
+    }
+
+    #[test]
+    fn desktop_uses_rpm_name_for_exec() {
+        let mc: RpmMakeConfig =
+            serde_yaml::from_str("display_name: Hola\npackage_name: hola-amigos\n").unwrap();
+        let desktop = mc.desktop_file(&test_config());
+        assert!(desktop.contains("Name=Hola"));
+        assert!(desktop.contains("Icon=hola-amigos"));
+        assert!(desktop.contains("Exec=hola-amigos %U"));
     }
 }

--- a/crates/app_packager/src/macos/dmg.rs
+++ b/crates/app_packager/src/macos/dmg.rs
@@ -58,30 +58,14 @@ impl AppPackager for MacOSDmgPackager {
 
         let output_file = config.output_file();
 
-        // Build the DMG spec programmatically.
-        // Paths in the spec are relative to the packaging directory (basepath).
-        let escaped_name = config.app_name.replace('\\', "\\\\").replace('"', "\\\"");
-        let mut contents = vec![
-            json!({"x": 448, "y": 344, "type": "link", "path": "/Applications"}),
-            json!({"x": 192, "y": 344, "type": "file", "path": format!("{escaped_name}.app")}),
-        ];
-
-        // Only include a background if background.png actually exists in the
-        // packaging dir (from dmg_assets) — dmg_maker errors out trying to
-        // copy a background file that was declared but never provided.
-        let has_background = pkg_dir.join("background.png").exists();
-        if has_background {
-            contents.push(json!({"x": 0, "y": 0, "type": "position"}));
-        }
-
-        let mut spec = json!({
-            "title": escaped_name,
-            "icon-size": 80,
-            "contents": contents,
-        });
-        if has_background {
-            spec["background"] = json!("background.png");
-        }
+        // Prefer the project's `macos/packaging/dmg/make_config.yaml` (same
+        // appdmg-format schema as Dart's `MakeDmgConfig`: title, icon,
+        // background, background-color, icon-size, format, window, code-sign,
+        // contents). Fall back to a default spec when it's absent.
+        let spec = match load_dmg_make_config(Path::new("macos/packaging/dmg/make_config.yaml"))? {
+            Some(spec) => spec,
+            None => default_spec(&config.app_name, &pkg_dir),
+        };
 
         // Delegate DMG creation to the native dmg_maker crate.
         create(CreateOptions {
@@ -99,6 +83,50 @@ impl AppPackager for MacOSDmgPackager {
             artifacts: vec![output_file],
         })
     }
+}
+
+/// Loads `macos/packaging/dmg/make_config.yaml` as an appdmg-style JSON spec.
+/// Returns `Ok(None)` when the file does not exist.
+fn load_dmg_make_config(path: &Path) -> Result<Option<serde_json::Value>, PackageError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| PackageError::General(format!("Failed to read {}: {}", path.display(), e)))?;
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&content)
+        .map_err(|e| PackageError::General(format!("Failed to parse {}: {}", path.display(), e)))?;
+    let spec = serde_json::to_value(yaml).map_err(|e| {
+        PackageError::General(format!("Failed to convert {} to JSON: {}", path.display(), e))
+    })?;
+    Ok(Some(spec))
+}
+
+/// The default spec used when no `make_config.yaml` is provided.
+/// Paths in the spec are relative to the packaging directory (basepath).
+fn default_spec(app_name: &str, pkg_dir: &Path) -> serde_json::Value {
+    let escaped_name = app_name.replace('\\', "\\\\").replace('"', "\\\"");
+    let mut contents = vec![
+        json!({"x": 448, "y": 344, "type": "link", "path": "/Applications"}),
+        json!({"x": 192, "y": 344, "type": "file", "path": format!("{escaped_name}.app")}),
+    ];
+
+    // Only include a background if background.png actually exists in the
+    // packaging dir (from dmg_assets) — dmg_maker errors out trying to
+    // copy a background file that was declared but never provided.
+    let has_background = pkg_dir.join("background.png").exists();
+    if has_background {
+        contents.push(json!({"x": 0, "y": 0, "type": "position"}));
+    }
+
+    let mut spec = json!({
+        "title": escaped_name,
+        "icon-size": 80,
+        "contents": contents,
+    });
+    if has_background {
+        spec["background"] = json!("background.png");
+    }
+    spec
 }
 
 /// Copy a file or directory recursively.
@@ -166,5 +194,72 @@ fn map_dmg_error(err: DmgMakerError) -> PackageError {
         DmgMakerError::Io(e) => PackageError::Io(e),
         DmgMakerError::Json(e) => PackageError::General(format!("JSON error: {e}")),
         DmgMakerError::General(msg) => PackageError::General(msg),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_config_yaml_converts_to_appdmg_spec() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("make_config.yaml");
+        std::fs::write(
+            &path,
+            r#"
+title: Hola Amigos
+icon: AppIcon.icns
+background: background.png
+icon-size: 100
+window:
+  position:
+    x: 100
+    y: 100
+  size:
+    width: 600
+    height: 400
+code-sign:
+  signing-identity: "Developer ID Application: Foo"
+contents:
+  - x: 448
+    y: 344
+    type: link
+    path: /Applications
+  - x: 192
+    y: 344
+    type: file
+    path: Hola Amigos.app
+"#,
+        )
+        .unwrap();
+        let spec = load_dmg_make_config(&path).unwrap().unwrap();
+        assert_eq!(spec["title"], "Hola Amigos");
+        assert_eq!(spec["icon-size"], 100);
+        assert_eq!(spec["window"]["size"]["width"], 600);
+        assert_eq!(
+            spec["code-sign"]["signing-identity"],
+            "Developer ID Application: Foo"
+        );
+        assert_eq!(spec["contents"][1]["type"], "file");
+    }
+
+    #[test]
+    fn missing_make_config_returns_none() {
+        assert!(
+            load_dmg_make_config(std::path::Path::new("/nonexistent/make_config.yaml"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn default_spec_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let spec = default_spec("Demo", dir.path());
+        assert_eq!(spec["title"], "Demo");
+        assert_eq!(spec["icon-size"], 80);
+        assert_eq!(spec["contents"].as_array().unwrap().len(), 2);
+        assert!(spec.get("background").is_none());
     }
 }

--- a/crates/app_packager/src/web/direct.rs
+++ b/crates/app_packager/src/web/direct.rs
@@ -32,7 +32,9 @@ impl AppPackager for WebDirectPackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
-        let dst = config.version_output_dir().join(&config.app_name);
+        // Mirrors Dart: the destination directory uses the rendered artifact
+        // name (no extension for direct output).
+        let dst = config.output_file();
         copy_dir(&config.build_output_dir, &dst)?;
         Ok(PackageResult {
             artifacts: vec![dst],

--- a/crates/app_packager/src/windows/direct.rs
+++ b/crates/app_packager/src/windows/direct.rs
@@ -39,7 +39,9 @@ impl AppPackager for WindowsDirectPackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
-        let dst = config.version_output_dir().join(&config.app_name);
+        // Mirrors Dart: the destination directory uses the rendered artifact
+        // name (no extension for direct output).
+        let dst = config.output_file();
         copy_dir(&config.build_output_dir, &dst)?;
         Ok(PackageResult {
             artifacts: vec![dst],

--- a/crates/app_packager/src/windows/exe.rs
+++ b/crates/app_packager/src/windows/exe.rs
@@ -1,12 +1,293 @@
+use std::path::Path;
 use std::process::Command;
 
 use fastforge_core::{AppPackager, PackageConfig, PackageError, PackageResult, Platform};
+use serde::Deserialize;
 
 /// Builds a Windows `.exe` installer using Inno Setup (`iscc`), mirroring
 /// Dart's `AppPackageMakerExe`.
 ///
-/// Requires Inno Setup (`iscc`) to be on `%PATH%` (Windows only).
+/// Reads `windows/packaging/exe/make_config.yaml` when present (same schema
+/// as Dart's `MakeExeConfig`); falls back to sensible defaults otherwise.
+///
+/// Requires Inno Setup (`iscc`) to be on `%PATH%`, in the default install
+/// location, or pointed to by the `INNO_SETUP_PATH` environment variable
+/// (Windows only).
 pub struct WindowsExePackager;
+
+/// Maps locale codes to Inno Setup language metadata:
+/// `(locale, language name, .isl file)`. Mirrors Dart's
+/// `_localeToLanguageFile` + `[Languages]` template block.
+const LOCALE_LANGUAGES: &[(&str, &str, &str)] = &[
+    ("en", "english", "Default.isl"),
+    ("hy", "armenian", "Armenian.isl"),
+    ("bg", "bulgarian", "Bulgarian.isl"),
+    ("ca", "catalan", "Catalan.isl"),
+    ("zh", "chinesesimplified", "ChineseSimplified.isl"),
+    ("co", "corsican", "Corsican.isl"),
+    ("cs", "czech", "Czech.isl"),
+    ("da", "danish", "Danish.isl"),
+    ("nl", "dutch", "Dutch.isl"),
+    ("fi", "finnish", "Finnish.isl"),
+    ("fr", "french", "French.isl"),
+    ("de", "german", "German.isl"),
+    ("he", "hebrew", "Hebrew.isl"),
+    ("is", "icelandic", "Icelandic.isl"),
+    ("it", "italian", "Italian.isl"),
+    ("ja", "japanese", "Japanese.isl"),
+    ("no", "norwegian", "Norwegian.isl"),
+    ("pl", "polish", "Polish.isl"),
+    ("pt", "portuguese", "Portuguese.isl"),
+    ("ru", "russian", "Russian.isl"),
+    ("sk", "slovak", "Slovak.isl"),
+    ("sl", "slovenian", "Slovenian.isl"),
+    ("es", "spanish", "Spanish.isl"),
+    ("tr", "turkish", "Turkish.isl"),
+    ("uk", "ukrainian", "Ukrainian.isl"),
+];
+
+/// Schema of `windows/packaging/exe/make_config.yaml`, mirroring Dart's
+/// `MakeExeConfig.fromJson`.
+#[derive(Debug, Default, Deserialize)]
+pub struct ExeMakeConfig {
+    pub script_template: Option<String>,
+    #[serde(alias = "appId")]
+    pub app_id: Option<String>,
+    pub executable_name: Option<String>,
+    pub display_name: Option<String>,
+    #[serde(alias = "appPublisher")]
+    pub publisher_name: Option<String>,
+    #[serde(alias = "appPublisherUrl")]
+    pub publisher_url: Option<String>,
+    pub create_desktop_icon: Option<bool>,
+    pub launch_at_startup: Option<bool>,
+    pub install_dir_name: Option<String>,
+    pub setup_icon_file: Option<String>,
+    pub privileges_required: Option<String>,
+    pub locales: Option<Vec<String>>,
+    pub architectures_allowed: Option<String>,
+    pub architectures_install_in_64bit_mode: Option<String>,
+}
+
+impl ExeMakeConfig {
+    fn load() -> Result<Self, PackageError> {
+        let path = Path::new("windows/packaging/exe/make_config.yaml");
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            PackageError::General(format!("Failed to read {}: {}", path.display(), e))
+        })?;
+        serde_yaml::from_str(&content).map_err(|e| {
+            PackageError::General(format!("Failed to parse {}: {}", path.display(), e))
+        })
+    }
+}
+
+/// Resolves the path to `ISCC.exe` using the same order as Dart's
+/// `InnoSetupCompiler`:
+/// 1. `INNO_SETUP_PATH` environment variable (a directory containing ISCC.exe)
+/// 2. The default install path (`C:\Program Files (x86)\Inno Setup 6`)
+/// 3. `iscc` found in `PATH`
+fn resolve_iscc_path() -> String {
+    if let Ok(env_path) = std::env::var("INNO_SETUP_PATH")
+        && !env_path.is_empty()
+    {
+        let iscc = std::path::Path::new(&env_path).join("ISCC.exe");
+        if iscc.exists() {
+            return iscc.display().to_string();
+        }
+    }
+    let default_iscc =
+        std::path::Path::new(r"C:\Program Files (x86)\Inno Setup 6").join("ISCC.exe");
+    if default_iscc.exists() {
+        return default_iscc.display().to_string();
+    }
+    "iscc".to_string()
+}
+
+/// Filters locales to those whose `.isl` files exist at the resolved Inno
+/// Setup location, mirroring Dart's `_getAvailableLocales`. When iscc is only
+/// available via `PATH` the directory is unknown, so all locales are kept.
+fn available_locales(locales: &[String], iscc_path: &str) -> Vec<String> {
+    if locales.is_empty() {
+        return vec!["en".to_string()];
+    }
+    if iscc_path == "iscc" {
+        return locales.to_vec();
+    }
+    let inno_dir = Path::new(iscc_path).parent().unwrap_or(Path::new("."));
+    let mut available = Vec::new();
+    for locale in locales {
+        match LOCALE_LANGUAGES.iter().find(|(code, _, _)| code == locale) {
+            None => available.push(locale.clone()),
+            Some((code, _, isl)) => {
+                let isl_path = if *code == "en" {
+                    inno_dir.join(isl)
+                } else {
+                    inno_dir.join("Languages").join(isl)
+                };
+                if isl_path.exists() {
+                    available.push(locale.clone());
+                }
+            }
+        }
+    }
+    if available.is_empty() {
+        vec!["en".to_string()]
+    } else {
+        available
+    }
+}
+
+/// Renders the `[Languages]` section entries for the given locales.
+fn render_languages(locales: &[String]) -> String {
+    locales
+        .iter()
+        .filter_map(|locale| {
+            LOCALE_LANGUAGES
+                .iter()
+                .find(|(code, _, _)| code == locale)
+                .map(|(code, name, isl)| {
+                    if *code == "en" {
+                        format!("Name: \"{}\"; MessagesFile: \"compiler:{}\"", name, isl)
+                    } else {
+                        format!(
+                            "Name: \"{}\"; MessagesFile: \"compiler:Languages\\{}\"",
+                            name, isl
+                        )
+                    }
+                })
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+struct IssVariables {
+    app_id: String,
+    app_version: String,
+    display_name: String,
+    publisher_name: String,
+    publisher_url: String,
+    install_dir_name: String,
+    output_base_filename: String,
+    setup_icon_file: String,
+    privileges_required: String,
+    architectures_allowed: String,
+    architectures_install_in_64bit_mode: String,
+    source_dir: String,
+    executable_name: String,
+    create_desktop_icon: bool,
+    launch_at_startup: bool,
+    locales: Vec<String>,
+}
+
+impl IssVariables {
+    /// Renders the default `.iss` script, producing the same output as Dart's
+    /// Liquid `_template`.
+    fn render_default(&self) -> String {
+        let run_flags = if self.privileges_required == "admin" {
+            "runascurrentuser nowait postinstall skipifsilent"
+        } else {
+            " nowait postinstall skipifsilent"
+        };
+        format!(
+            "[Setup]\n\
+             AppId={app_id}\n\
+             AppVersion={app_version}\n\
+             AppName={display_name}\n\
+             AppPublisher={publisher_name}\n\
+             AppPublisherURL={publisher_url}\n\
+             AppSupportURL={publisher_url}\n\
+             AppUpdatesURL={publisher_url}\n\
+             DefaultDirName={install_dir_name}\n\
+             DisableProgramGroupPage=yes\n\
+             OutputDir=.\n\
+             OutputBaseFilename={output_base_filename}\n\
+             Compression=lzma\n\
+             SolidCompression=yes\n\
+             SetupIconFile={setup_icon_file}\n\
+             WizardStyle=modern\n\
+             PrivilegesRequired={privileges_required}\n\
+             ArchitecturesAllowed={architectures_allowed}\n\
+             ArchitecturesInstallIn64BitMode={architectures_install_in_64bit_mode}\n\
+             \n\
+             [Languages]\n\
+             {languages}\n\
+             \n\
+             [Tasks]\n\
+             Name: \"desktopicon\"; Description: \"{{cm:CreateDesktopIcon}}\"; GroupDescription: \"{{cm:AdditionalIcons}}\"; Flags: {desktop_icon_flags}\n\
+             Name: \"launchAtStartup\"; Description: \"{{cm:AutoStartProgram,{display_name}}}\"; GroupDescription: \"{{cm:AdditionalIcons}}\"; Flags: {startup_flags}\n\
+             [Files]\n\
+             Source: \"{source_dir}\\*\"; DestDir: \"{{app}}\"; Flags: ignoreversion recursesubdirs createallsubdirs\n\
+             ; NOTE: Don't use \"Flags: ignoreversion\" on any shared system files\n\
+             \n\
+             [Icons]\n\
+             Name: \"{{autoprograms}}\\{display_name}\"; Filename: \"{{app}}\\{executable_name}\"\n\
+             Name: \"{{autodesktop}}\\{display_name}\"; Filename: \"{{app}}\\{executable_name}\"; Tasks: desktopicon\n\
+             Name: \"{{userstartup}}\\{display_name}\"; Filename: \"{{app}}\\{executable_name}\"; WorkingDir: \"{{app}}\"; Tasks: launchAtStartup\n\
+             [Run]\n\
+             Filename: \"{{app}}\\{executable_name}\"; Description: \"{{cm:LaunchProgram,{display_name}}}\"; Flags: {run_flags}\n",
+            app_id = self.app_id,
+            app_version = self.app_version,
+            display_name = self.display_name,
+            publisher_name = self.publisher_name,
+            publisher_url = self.publisher_url,
+            install_dir_name = self.install_dir_name,
+            output_base_filename = self.output_base_filename,
+            setup_icon_file = self.setup_icon_file,
+            privileges_required = self.privileges_required,
+            architectures_allowed = self.architectures_allowed,
+            architectures_install_in_64bit_mode = self.architectures_install_in_64bit_mode,
+            languages = render_languages(&self.locales),
+            desktop_icon_flags = if self.create_desktop_icon {
+                "checkedonce"
+            } else {
+                "unchecked"
+            },
+            startup_flags = if self.launch_at_startup {
+                "checkedonce"
+            } else {
+                "unchecked"
+            },
+            source_dir = self.source_dir,
+            executable_name = self.executable_name,
+            run_flags = run_flags,
+        )
+    }
+
+    /// Substitutes `{{VAR}}` placeholders in a user-provided template.
+    /// (Liquid `{% %}` logic blocks are not supported; simple variable
+    /// substitution covers the common custom-template case.)
+    fn render_template(&self, template: &str) -> String {
+        let pairs: Vec<(&str, String)> = vec![
+            ("APP_ID", self.app_id.clone()),
+            ("APP_VERSION", self.app_version.clone()),
+            ("DISPLAY_NAME", self.display_name.clone()),
+            ("PUBLISHER_NAME", self.publisher_name.clone()),
+            ("PUBLISHER_URL", self.publisher_url.clone()),
+            ("INSTALL_DIR_NAME", self.install_dir_name.clone()),
+            ("OUTPUT_BASE_FILENAME", self.output_base_filename.clone()),
+            ("SETUP_ICON_FILE", self.setup_icon_file.clone()),
+            ("PRIVILEGES_REQUIRED", self.privileges_required.clone()),
+            (
+                "ARCHITECTURES_ALLOWED",
+                self.architectures_allowed.clone(),
+            ),
+            (
+                "ARCHITECTURES_INSTALL_IN_64BIT_MODE",
+                self.architectures_install_in_64bit_mode.clone(),
+            ),
+            ("SOURCE_DIR", self.source_dir.clone()),
+            ("EXECUTABLE_NAME", self.executable_name.clone()),
+        ];
+        let mut output = template.to_string();
+        for (key, value) in pairs {
+            output = output.replace(&format!("{{{{{}}}}}", key), &value);
+        }
+        output
+    }
+}
 
 fn run(cmd: &mut Command) -> Result<(), PackageError> {
     let out = cmd.output().map_err(|e| {
@@ -40,6 +321,7 @@ impl AppPackager for WindowsExePackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
+        let make_config = ExeMakeConfig::load()?;
         let pkg_dir = config.packaging_dir();
 
         // Copy the flutter build output into the packaging directory
@@ -52,41 +334,193 @@ impl AppPackager for WindowsExePackager {
         ]))?;
 
         let output_file = config.output_file();
-        let output_dir = output_file
-            .parent()
-            .unwrap_or(std::path::Path::new("."))
-            .display()
-            .to_string();
-        let output_basename = output_file
+        let output_base_filename = output_file
             .file_stem()
             .unwrap_or_default()
             .to_string_lossy()
             .into_owned();
 
-        // Build a minimal Inno Setup .iss script
-        let iss = format!(
-            "[Setup]\n\
-             AppName={name}\n\
-             AppVersion={ver}\n\
-             DefaultDirName={{autopf}}\\{name}\n\
-             OutputDir={out_dir}\n\
-             OutputBaseFilename={out_name}\n\
-             [Files]\n\
-             Source: \"{src}\\*\"; DestDir: \"{{app}}\"; Flags: ignoreversion recursesubdirs\n",
-            name = config.app_name,
-            ver = config.app_version,
-            out_dir = output_dir,
-            out_name = output_basename,
-            src = pkg_dir.display(),
+        // Default executable: the first .exe in the packaging directory
+        // (mirrors Dart's `defaultExecutableName`).
+        let executable_name = match &make_config.executable_name {
+            Some(name) => name.clone(),
+            None => std::fs::read_dir(&pkg_dir)?
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .find(|p| p.extension().is_some_and(|x| x == "exe"))
+                .and_then(|p| p.file_name().map(|f| f.to_string_lossy().to_string()))
+                .unwrap_or_else(|| format!("{}.exe", config.app_binary_name)),
+        };
+
+        // Absolute setup icon path (mirrors Dart, which joins with cwd)
+        let setup_icon_file = make_config
+            .setup_icon_file
+            .as_ref()
+            .map(|icon| {
+                std::env::current_dir()
+                    .map(|cwd| cwd.join(icon).display().to_string())
+                    .unwrap_or_else(|_| icon.clone())
+            })
+            .unwrap_or_default();
+
+        let iscc_path = resolve_iscc_path();
+        let locales = available_locales(
+            &make_config
+                .locales
+                .clone()
+                .unwrap_or_else(|| vec!["en".to_string()]),
+            &iscc_path,
         );
-        let iss_path = pkg_dir.join(format!("{}.iss", config.app_name));
-        std::fs::write(&iss_path, &iss)?;
 
-        run(Command::new("iscc").arg(&iss_path))?;
+        let variables = IssVariables {
+            app_id: make_config
+                .app_id
+                .clone()
+                .unwrap_or_else(|| config.app_name.clone()),
+            app_version: config.app_version.clone(),
+            display_name: make_config
+                .display_name
+                .clone()
+                .unwrap_or_else(|| config.app_name.clone()),
+            publisher_name: make_config.publisher_name.clone().unwrap_or_default(),
+            publisher_url: make_config.publisher_url.clone().unwrap_or_default(),
+            install_dir_name: make_config
+                .install_dir_name
+                .clone()
+                .unwrap_or_else(|| format!("{{autopf64}}\\{}", config.app_name)),
+            output_base_filename,
+            setup_icon_file,
+            privileges_required: make_config
+                .privileges_required
+                .clone()
+                .unwrap_or_else(|| "none".to_string()),
+            architectures_allowed: make_config
+                .architectures_allowed
+                .clone()
+                .unwrap_or_else(|| "x64compatible".to_string()),
+            architectures_install_in_64bit_mode: make_config
+                .architectures_install_in_64bit_mode
+                .clone()
+                .unwrap_or_else(|| "x64compatible".to_string()),
+            source_dir: pkg_dir
+                .file_name()
+                .map(|f| f.to_string_lossy().to_string())
+                .unwrap_or_default(),
+            executable_name,
+            create_desktop_icon: make_config.create_desktop_icon.unwrap_or(false),
+            launch_at_startup: make_config.launch_at_startup.unwrap_or(false),
+            locales,
+        };
 
+        // Render the script (custom template when configured, mirroring
+        // Dart's `script_template` support)
+        let content = match &make_config.script_template {
+            Some(template_name) => {
+                let template_path = Path::new("windows/packaging/exe").join(template_name);
+                let template = std::fs::read_to_string(&template_path).map_err(|e| {
+                    PackageError::General(format!(
+                        "Failed to read script template {}: {}",
+                        template_path.display(),
+                        e
+                    ))
+                })?;
+                variables.render_template(&template)
+            }
+            None => variables.render_default(),
+        };
+
+        // The .iss file sits next to the packaging directory (in the version
+        // output dir), so `OutputDir=.` and `SOURCE_DIR\*` resolve correctly.
+        // A UTF-8 BOM is prepended, mirroring Dart.
+        let iss_path = pkg_dir.with_extension("iss");
+        std::fs::write(&iss_path, format!("\u{FEFF}{}", content))?;
+
+        run(Command::new(&iscc_path).arg(&iss_path))?;
+
+        std::fs::remove_file(&iss_path).ok();
         std::fs::remove_dir_all(&pkg_dir).ok();
         Ok(PackageResult {
             artifacts: vec![output_file],
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_variables() -> IssVariables {
+        IssVariables {
+            app_id: "6BCF1E88-6912-4D77-8FE8-B10A2A1B5A0E".into(),
+            app_version: "1.2.3+4".into(),
+            display_name: "Hola Amigos".into(),
+            publisher_name: "ACME".into(),
+            publisher_url: "https://example.com".into(),
+            install_dir_name: "{autopf64}\\hola_amigos".into(),
+            output_base_filename: "hola_amigos-1.2.3+4-windows-setup".into(),
+            setup_icon_file: "C:\\proj\\icon.ico".into(),
+            privileges_required: "admin".into(),
+            architectures_allowed: "x64compatible".into(),
+            architectures_install_in_64bit_mode: "x64compatible".into(),
+            source_dir: "hola_amigos-1.2.3+4-windows-setup_exe".into(),
+            executable_name: "hola_amigos.exe".into(),
+            create_desktop_icon: true,
+            launch_at_startup: false,
+            locales: vec!["en".into(), "zh".into()],
+        }
+    }
+
+    #[test]
+    fn default_script_contains_all_sections() {
+        let iss = test_variables().render_default();
+        assert!(iss.contains("AppId=6BCF1E88-6912-4D77-8FE8-B10A2A1B5A0E"));
+        assert!(iss.contains("AppVersion=1.2.3+4"));
+        assert!(iss.contains("AppName=Hola Amigos"));
+        assert!(iss.contains("AppPublisher=ACME"));
+        assert!(iss.contains("AppPublisherURL=https://example.com"));
+        assert!(iss.contains("DefaultDirName={autopf64}\\hola_amigos"));
+        assert!(iss.contains("SetupIconFile=C:\\proj\\icon.ico"));
+        assert!(iss.contains("PrivilegesRequired=admin"));
+        assert!(iss.contains("ArchitecturesAllowed=x64compatible"));
+        assert!(iss.contains("Name: \"english\"; MessagesFile: \"compiler:Default.isl\""));
+        assert!(iss.contains(
+            "Name: \"chinesesimplified\"; MessagesFile: \"compiler:Languages\\ChineseSimplified.isl\""
+        ));
+        assert!(iss.contains("Name: \"desktopicon\""));
+        assert!(iss.contains("Flags: checkedonce\n"));
+        assert!(iss.contains("Name: \"launchAtStartup\""));
+        assert!(iss.contains("Source: \"hola_amigos-1.2.3+4-windows-setup_exe\\*\""));
+        assert!(iss.contains("Filename: \"{app}\\hola_amigos.exe\""));
+        assert!(iss.contains("Flags: runascurrentuser nowait postinstall skipifsilent"));
+    }
+
+    #[test]
+    fn non_admin_run_flags() {
+        let mut vars = test_variables();
+        vars.privileges_required = "none".into();
+        let iss = vars.render_default();
+        assert!(iss.contains("Flags:  nowait postinstall skipifsilent"));
+        assert!(!iss.contains("runascurrentuser"));
+    }
+
+    #[test]
+    fn custom_template_substitution() {
+        let iss = test_variables().render_template(
+            "[Setup]\nAppId={{APP_ID}}\nAppName={{DISPLAY_NAME}}\nSource: \"{{SOURCE_DIR}}\\*\"",
+        );
+        assert_eq!(
+            iss,
+            "[Setup]\nAppId=6BCF1E88-6912-4D77-8FE8-B10A2A1B5A0E\nAppName=Hola Amigos\nSource: \"hola_amigos-1.2.3+4-windows-setup_exe\\*\""
+        );
+    }
+
+    #[test]
+    fn locales_fall_back_to_english() {
+        assert_eq!(available_locales(&[], "iscc"), vec!["en".to_string()]);
+        // With PATH-resolved iscc all locales are kept
+        assert_eq!(
+            available_locales(&["en".to_string(), "zh".to_string()], "iscc"),
+            vec!["en".to_string(), "zh".to_string()]
+        );
     }
 }

--- a/crates/app_packager/src/windows/msix.rs
+++ b/crates/app_packager/src/windows/msix.rs
@@ -1,21 +1,295 @@
+use std::path::Path;
 use std::process::Command;
 
 use fastforge_core::{AppPackager, PackageConfig, PackageError, PackageResult, Platform};
+use serde::Deserialize;
 
 /// Builds a Windows `.msix` package using the `makeappx` / `signtool` SDK tools,
-/// mirroring Dart's `AppPackageMakerMsix`.
+/// mirroring Dart's `AppPackageMakerMsix` (which delegates to the `msix` pub
+/// package).
+///
+/// Reads `windows/packaging/msix/make_config.yaml` when present (same schema
+/// as Dart's `MakeMsixConfig`); falls back to sensible defaults otherwise.
 ///
 /// Requires the Windows 10 SDK tools (`makeappx`, `signtool`) on Windows.
 #[derive(Default)]
 pub struct WindowsMsixPackager {
-    /// Optional path to a PFX certificate for signing.
+    /// Optional path to a PFX certificate for signing (overrides make_config).
     pub certificate_path: Option<String>,
-    /// Optional PFX certificate password.
+    /// Optional PFX certificate password (overrides make_config).
     pub certificate_password: Option<String>,
-    /// Publisher distinguished name used in AppxManifest, e.g.
-    /// `"CN=My Company, O=My Company, L=City, S=State, C=US"`.
-    /// Defaults to `"CN=Publisher"` when not set.
+    /// Publisher distinguished name used in AppxManifest (overrides
+    /// make_config), e.g. `"CN=My Company, O=My Company, C=US"`.
     pub publisher: Option<String>,
+}
+
+/// Schema of `windows/packaging/msix/make_config.yaml`, mirroring Dart's
+/// `MakeMsixConfig`. Values may be written as strings or natural YAML types.
+#[derive(Debug, Default, Deserialize)]
+pub struct MsixMakeConfig {
+    pub display_name: Option<String>,
+    pub publisher_display_name: Option<String>,
+    pub identity_name: Option<String>,
+    pub msix_version: Option<String>,
+    pub logo_path: Option<String>,
+    /// Comma-separated capability list, e.g. `"internetClient,microphone"`.
+    pub capabilities: Option<String>,
+    /// Comma-separated language list, e.g. `"en-us, zh-cn"`.
+    pub languages: Option<String>,
+    /// Comma-separated file extensions the app registers to open.
+    pub file_extension: Option<String>,
+    /// Protocol activation scheme(s), comma-separated.
+    pub protocol_activation: Option<String>,
+    pub add_execution_alias: Option<String>,
+    pub enable_at_startup: Option<String>,
+    pub architecture: Option<String>,
+    pub certificate_path: Option<String>,
+    pub certificate_password: Option<String>,
+    pub publisher: Option<String>,
+    /// Extra options passed verbatim to `signtool sign`.
+    pub signtool_options: Option<String>,
+    /// If `"false"`, don't sign the msix file.
+    pub sign_msix: Option<String>,
+}
+
+impl MsixMakeConfig {
+    fn load() -> Result<Self, PackageError> {
+        let path = Path::new("windows/packaging/msix/make_config.yaml");
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            PackageError::General(format!("Failed to read {}: {}", path.display(), e))
+        })?;
+        serde_yaml::from_str(&content).map_err(|e| {
+            PackageError::General(format!("Failed to parse {}: {}", path.display(), e))
+        })
+    }
+}
+
+fn is_false(value: &Option<String>) -> bool {
+    value
+        .as_deref()
+        .is_some_and(|v| v.eq_ignore_ascii_case("false"))
+}
+
+fn is_true(value: &Option<String>) -> bool {
+    value
+        .as_deref()
+        .is_some_and(|v| v.eq_ignore_ascii_case("true"))
+}
+
+fn split_list(value: &Option<String>) -> Vec<String> {
+    value
+        .as_deref()
+        .unwrap_or("")
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Derives an `a.b.c.d` MSIX version from the app version (e.g. `1.2.3+4`
+/// becomes `1.2.3.0`), mirroring the msix pub package's default.
+fn msix_version_from(app_version: &str) -> String {
+    let base = app_version.split('+').next().unwrap_or(app_version);
+    let numeric: Vec<String> = base
+        .split('.')
+        .map(|part| {
+            part.chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
+        })
+        .map(|p| if p.is_empty() { "0".to_string() } else { p })
+        .collect();
+    let mut parts = numeric;
+    parts.resize(3, "0".to_string());
+    format!("{}.{}.{}.0", parts[0], parts[1], parts[2])
+}
+
+/// Detects the target architecture from the build output directory path
+/// (mirrors Dart's `_detectArchitecture`): Flutter 3.22+ uses
+/// `build/windows/{x64,arm64}/runner/Release`.
+fn detect_architecture(build_output_dir: &Path) -> &'static str {
+    if build_output_dir
+        .to_string_lossy()
+        .to_lowercase()
+        .contains("arm64")
+    {
+        "arm64"
+    } else {
+        "x64"
+    }
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Renders the AppxManifest.xml from the configuration.
+fn render_manifest(
+    make_config: &MsixMakeConfig,
+    config: &PackageConfig,
+    publisher: &str,
+    logo_file: Option<&str>,
+) -> String {
+    let display_name = make_config
+        .display_name
+        .clone()
+        .unwrap_or_else(|| config.app_name.clone());
+    let identity_name = make_config
+        .identity_name
+        .clone()
+        .unwrap_or_else(|| config.app_name.clone());
+    let version = make_config
+        .msix_version
+        .clone()
+        .unwrap_or_else(|| msix_version_from(&config.app_version));
+    let publisher_display_name = make_config
+        .publisher_display_name
+        .clone()
+        .unwrap_or_else(|| "Publisher".to_string());
+    let architecture = make_config
+        .architecture
+        .clone()
+        .unwrap_or_else(|| detect_architecture(&config.build_output_dir).to_string());
+
+    let logo = logo_file.unwrap_or("Assets\\StoreLogo.png");
+
+    let languages = {
+        let list = split_list(&make_config.languages);
+        let list = if list.is_empty() {
+            vec!["en-us".to_string()]
+        } else {
+            list
+        };
+        list.into_iter()
+            .map(|l| format!("    <Resource Language=\"{}\"/>", xml_escape(&l)))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let mut capabilities: Vec<String> =
+        vec!["    <rescap:Capability Name=\"runFullTrust\"/>".to_string()];
+    for capability in split_list(&make_config.capabilities) {
+        // Device capabilities vs regular capabilities (subset of the msix
+        // pub package's mapping; unknown names fall back to <Capability>).
+        let device_caps = ["microphone", "webcam", "location", "bluetooth"];
+        if device_caps.contains(&capability.as_str()) {
+            capabilities.push(format!(
+                "    <DeviceCapability Name=\"{}\"/>",
+                xml_escape(&capability)
+            ));
+        } else {
+            capabilities.push(format!(
+                "    <Capability Name=\"{}\"/>",
+                xml_escape(&capability)
+            ));
+        }
+    }
+
+    // Application-level extensions
+    let mut extensions = Vec::new();
+    let file_extensions = split_list(&make_config.file_extension);
+    if !file_extensions.is_empty() {
+        let types = file_extensions
+            .iter()
+            .map(|e| {
+                let ext = e.strip_prefix('.').unwrap_or(e);
+                format!("              <uap:FileType>.{}</uap:FileType>", xml_escape(ext))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        extensions.push(format!(
+            "        <uap:Extension Category=\"windows.fileTypeAssociation\">\n          <uap:FileTypeAssociation Name=\"fileassociations\">\n            <uap:SupportedFileTypes>\n{}\n            </uap:SupportedFileTypes>\n          </uap:FileTypeAssociation>\n        </uap:Extension>",
+            types
+        ));
+    }
+    for protocol in split_list(&make_config.protocol_activation) {
+        extensions.push(format!(
+            "        <uap:Extension Category=\"windows.protocol\">\n          <uap:Protocol Name=\"{}\"/>\n        </uap:Extension>",
+            xml_escape(&protocol)
+        ));
+    }
+    if let Some(alias) = make_config
+        .add_execution_alias
+        .as_deref()
+        .filter(|a| !a.is_empty() && !a.eq_ignore_ascii_case("false"))
+    {
+        let alias_name = if alias.eq_ignore_ascii_case("true") {
+            config.app_name.replace('_', "").to_lowercase()
+        } else {
+            alias.to_string()
+        };
+        extensions.push(format!(
+            "        <uap3:Extension Category=\"windows.appExecutionAlias\" Executable=\"{bin}.exe\" EntryPoint=\"Windows.FullTrustApplication\">\n          <uap3:AppExecutionAlias>\n            <desktop:ExecutionAlias Alias=\"{alias}.exe\"/>\n          </uap3:AppExecutionAlias>\n        </uap3:Extension>",
+            bin = xml_escape(&config.app_binary_name),
+            alias = xml_escape(&alias_name),
+        ));
+    }
+    if is_true(&make_config.enable_at_startup) {
+        extensions.push(format!(
+            "        <desktop:Extension Category=\"windows.startupTask\" Executable=\"{bin}.exe\" EntryPoint=\"Windows.FullTrustApplication\">\n          <desktop:StartupTask TaskId=\"startupTask\" Enabled=\"true\" DisplayName=\"{name}\"/>\n        </desktop:Extension>",
+            bin = xml_escape(&config.app_binary_name),
+            name = xml_escape(&display_name),
+        ));
+    }
+    let extensions_block = if extensions.is_empty() {
+        String::new()
+    } else {
+        format!("\n      <Extensions>\n{}\n      </Extensions>", extensions.join("\n"))
+    };
+
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+         xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+  <Identity Name="{identity}" Publisher="{publisher}" Version="{version}" ProcessorArchitecture="{arch}"/>
+  <Properties>
+    <DisplayName>{display_name}</DisplayName>
+    <PublisherDisplayName>{publisher_display_name}</PublisherDisplayName>
+    <Logo>{logo}</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22000.0"/>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22000.0"/>
+  </Dependencies>
+  <Resources>
+{languages}
+  </Resources>
+  <Applications>
+    <Application Id="App" Executable="{bin}.exe" EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements DisplayName="{display_name}" Description="{display_name}" BackgroundColor="transparent" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile/>
+        <uap:SplashScreen Image="Assets\SplashScreen.png"/>
+      </uap:VisualElements>{extensions}
+    </Application>
+  </Applications>
+  <Capabilities>
+{capabilities}
+  </Capabilities>
+</Package>
+"#,
+        identity = xml_escape(&identity_name),
+        publisher = xml_escape(publisher),
+        version = xml_escape(&version),
+        arch = xml_escape(&architecture),
+        display_name = xml_escape(&display_name),
+        publisher_display_name = xml_escape(&publisher_display_name),
+        logo = logo,
+        languages = languages,
+        bin = xml_escape(&config.app_binary_name),
+        extensions = extensions_block,
+        capabilities = capabilities.join("\n"),
+    )
 }
 
 fn run(cmd: &mut Command) -> Result<(), PackageError> {
@@ -50,6 +324,7 @@ impl AppPackager for WindowsMsixPackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError> {
+        let make_config = MsixMakeConfig::load()?;
         let pkg_dir = config.packaging_dir();
 
         // Copy the flutter build output
@@ -61,39 +336,38 @@ impl AppPackager for WindowsMsixPackager {
             &pkg_dir.display().to_string(),
         ]))?;
 
-        // Write a minimal AppxManifest.xml
-        let publisher = self.publisher.as_deref().unwrap_or("CN=Publisher");
-        let manifest = format!(
-            r#"<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
-  <Identity Name="{name}" Publisher="{publisher}" Version="{ver}.0"/>
-  <Properties>
-    <DisplayName>{name}</DisplayName>
-    <PublisherDisplayName>Publisher</PublisherDisplayName>
-    <Logo>Assets\StoreLogo.png</Logo>
-  </Properties>
-  <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0"/>
-  </Dependencies>
-  <Resources><Resource Language="en-us"/></Resources>
-  <Applications>
-    <Application Id="App" Executable="{bin}.exe" EntryPoint="Windows.FullTrustApplication">
-      <uap:VisualElements DisplayName="{name}" Description="{name}" BackgroundColor="transparent" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png">
-        <uap:DefaultTile/>
-        <uap:SplashScreen Image="Assets\SplashScreen.png"/>
-      </uap:VisualElements>
-    </Application>
-  </Applications>
-  <Capabilities><rescap:Capability Name="runFullTrust"/></Capabilities>
-</Package>
-"#,
-            name = config.app_name,
-            publisher = publisher,
-            ver = config.app_version.split('+').next().unwrap_or("0.0.1"),
-            bin = config.app_binary_name,
-        );
+        // Install the configured logo into Assets/ (used for all logo slots)
+        let logo_file = if let Some(logo_path) = &make_config.logo_path {
+            let logo = Path::new(logo_path);
+            if !logo.exists() {
+                return Err(PackageError::NotFound(format!(
+                    "logo_path {} doesn't exist",
+                    logo_path
+                )));
+            }
+            let assets_dir = pkg_dir.join("Assets");
+            std::fs::create_dir_all(&assets_dir)?;
+            for name in [
+                "StoreLogo.png",
+                "Square150x150Logo.png",
+                "Square44x44Logo.png",
+                "SplashScreen.png",
+            ] {
+                std::fs::copy(logo, assets_dir.join(name))?;
+            }
+            Some("Assets\\StoreLogo.png")
+        } else {
+            None
+        };
+
+        // Publisher: struct field overrides make_config, then default
+        let publisher = self
+            .publisher
+            .clone()
+            .or_else(|| make_config.publisher.clone())
+            .unwrap_or_else(|| "CN=Publisher".to_string());
+
+        let manifest = render_manifest(&make_config, config, &publisher, logo_file);
         std::fs::write(pkg_dir.join("AppxManifest.xml"), &manifest)?;
 
         let output_file = config.output_file();
@@ -104,29 +378,146 @@ impl AppPackager for WindowsMsixPackager {
             "/p",
             &output_file.display().to_string(),
             "/nv",
+            "/o",
         ]))?;
 
-        // Optionally sign
-        if let Some(cert) = &self.certificate_path {
-            let mut args = vec![
-                "sign".to_string(),
-                "/fd".to_string(),
-                "SHA256".to_string(),
-                "/a".to_string(),
-                "/f".to_string(),
-                cert.clone(),
-            ];
-            if let Some(pwd) = &self.certificate_password {
-                args.push("/p".to_string());
-                args.push(pwd.clone());
+        // Sign unless disabled (mirrors the msix pub package's sign_msix flag)
+        let certificate_path = self
+            .certificate_path
+            .clone()
+            .or_else(|| make_config.certificate_path.clone());
+        let certificate_password = self
+            .certificate_password
+            .clone()
+            .or_else(|| make_config.certificate_password.clone());
+
+        if !is_false(&make_config.sign_msix) {
+            if let Some(signtool_options) = &make_config.signtool_options {
+                let mut args: Vec<String> = vec!["sign".to_string()];
+                args.extend(
+                    signtool_options
+                        .split_whitespace()
+                        .map(String::from),
+                );
+                args.push(output_file.display().to_string());
+                run(Command::new("signtool").args(&args))?;
+            } else if let Some(cert) = &certificate_path {
+                let mut args = vec![
+                    "sign".to_string(),
+                    "/fd".to_string(),
+                    "SHA256".to_string(),
+                    "/a".to_string(),
+                    "/f".to_string(),
+                    cert.clone(),
+                ];
+                if let Some(pwd) = &certificate_password {
+                    args.push("/p".to_string());
+                    args.push(pwd.clone());
+                }
+                args.push(output_file.display().to_string());
+                run(Command::new("signtool").args(&args))?;
             }
-            args.push(output_file.display().to_string());
-            run(Command::new("signtool").args(&args))?;
         }
 
         std::fs::remove_dir_all(&pkg_dir).ok();
         Ok(PackageResult {
             artifacts: vec![output_file],
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_config() -> PackageConfig {
+        PackageConfig {
+            app_name: "hola_amigos".into(),
+            app_binary_name: "hola_amigos".into(),
+            app_version: "1.2.3+4".into(),
+            build_mode: "release".into(),
+            platform: Platform::Windows,
+            flavor: None,
+            channel: None,
+            artifact_name: None,
+            package_format: "msix".into(),
+            is_installer: false,
+            build_output_dir: PathBuf::from("build/windows/x64/runner/Release"),
+            build_output_files: vec![],
+            output_dir: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn msix_version_derivation() {
+        assert_eq!(msix_version_from("1.2.3+4"), "1.2.3.0");
+        assert_eq!(msix_version_from("1.2.3"), "1.2.3.0");
+        assert_eq!(msix_version_from("2.0.0-beta.1+7"), "2.0.0.0");
+        assert_eq!(msix_version_from("1.2"), "1.2.0.0");
+    }
+
+    #[test]
+    fn architecture_detection() {
+        assert_eq!(
+            detect_architecture(Path::new("build/windows/arm64/runner/Release")),
+            "arm64"
+        );
+        assert_eq!(
+            detect_architecture(Path::new("build/windows/x64/runner/Release")),
+            "x64"
+        );
+        assert_eq!(detect_architecture(Path::new("build/windows/runner")), "x64");
+    }
+
+    #[test]
+    fn manifest_with_full_config() {
+        let mc: MsixMakeConfig = serde_yaml::from_str(
+            r#"
+display_name: Hola Amigos
+publisher_display_name: ACME Corp
+identity_name: com.acme.hola
+msix_version: 2.0.1.0
+languages: "en-us, zh-cn"
+capabilities: "internetClient,microphone"
+file_extension: ".txt,.md"
+protocol_activation: holaamigos
+add_execution_alias: hola
+enable_at_startup: "true"
+architecture: arm64
+"#,
+        )
+        .unwrap();
+        let manifest = render_manifest(&mc, &test_config(), "CN=ACME", None);
+        assert!(manifest.contains(
+            r#"<Identity Name="com.acme.hola" Publisher="CN=ACME" Version="2.0.1.0" ProcessorArchitecture="arm64"/>"#
+        ));
+        assert!(manifest.contains("<DisplayName>Hola Amigos</DisplayName>"));
+        assert!(manifest.contains("<PublisherDisplayName>ACME Corp</PublisherDisplayName>"));
+        assert!(manifest.contains(r#"<Resource Language="en-us"/>"#));
+        assert!(manifest.contains(r#"<Resource Language="zh-cn"/>"#));
+        assert!(manifest.contains(r#"<Capability Name="internetClient"/>"#));
+        assert!(manifest.contains(r#"<DeviceCapability Name="microphone"/>"#));
+        assert!(manifest.contains(r#"<rescap:Capability Name="runFullTrust"/>"#));
+        assert!(manifest.contains("<uap:FileType>.txt</uap:FileType>"));
+        assert!(manifest.contains("<uap:FileType>.md</uap:FileType>"));
+        assert!(manifest.contains(r#"<uap:Protocol Name="holaamigos"/>"#));
+        assert!(manifest.contains(r#"<desktop:ExecutionAlias Alias="hola.exe"/>"#));
+        assert!(manifest.contains("windows.startupTask"));
+    }
+
+    #[test]
+    fn manifest_defaults() {
+        let manifest = render_manifest(
+            &MsixMakeConfig::default(),
+            &test_config(),
+            "CN=Publisher",
+            None,
+        );
+        assert!(manifest.contains(
+            r#"<Identity Name="hola_amigos" Publisher="CN=Publisher" Version="1.2.3.0" ProcessorArchitecture="x64"/>"#
+        ));
+        assert!(manifest.contains(r#"<Resource Language="en-us"/>"#));
+        assert!(!manifest.contains("<Extensions>"));
     }
 }

--- a/crates/app_publisher/src/pgyer/mod.rs
+++ b/crates/app_publisher/src/pgyer/mod.rs
@@ -81,7 +81,7 @@ impl AppPublisher for PgyerPublisher {
         })?;
 
         let client = Client::new();
-        let token_data = self.get_cos_token(&client, &api_key, build_type)?;
+        let token_data = self.get_cos_token(&client, &api_key, build_type, config)?;
         let upload_key = self.upload_app(&client, artifact_path, &token_data, on_progress)?;
         let build_info = self.get_build_info_with_retry(&client, &api_key, &upload_key)?;
         let build_key = build_info.build_key;
@@ -99,10 +99,36 @@ impl PgyerPublisher {
         client: &Client,
         api_key: &str,
         build_type: &str,
+        config: &PublishConfig,
     ) -> Result<CosTokenData, PublishError> {
-        let form = Form::new()
+        let mut form = Form::new()
             .text("_api_key", api_key.to_string())
             .text("buildType", build_type.to_string());
+
+        // Optional pgyer API parameters, mirroring Dart's `PublishPgyerConfig`.
+        // See https://www.pgyer.com/doc/view/api#fastUploadApp
+        let optional_params = [
+            ("oversea", "oversea"),
+            ("install-type", "buildInstallType"),
+            ("password", "buildPassword"),
+            ("description", "buildDescription"),
+            ("update-description", "buildUpdateDescription"),
+            ("install-date", "buildInstallDate"),
+            ("install-start-date", "buildInstallStartDate"),
+            ("install-end-date", "buildInstallEndDate"),
+            ("channel-shortcut", "buildChannelShortcut"),
+        ];
+        if let Some(arguments) = config.publish_arguments.as_ref() {
+            for (arg_key, form_key) in optional_params {
+                if let Some(value) = arguments
+                    .get(arg_key)
+                    .or_else(|| arguments.get(&format!("pgyer-{arg_key}")))
+                    .filter(|v| !v.is_empty())
+                {
+                    form = form.text(form_key, value.clone());
+                }
+            }
+        }
         let response = client
             .post(GET_COS_TOKEN_URL)
             .multipart(form)

--- a/crates/app_publisher/src/s3/mod.rs
+++ b/crates/app_publisher/src/s3/mod.rs
@@ -37,6 +37,10 @@ const ENV_AWS_REGION: &str = "AWS_REGION";
 const ENV_AWS_ACCESS_KEY_ID: &str = "AWS_ACCESS_KEY_ID";
 const ENV_AWS_SECRET_ACCESS_KEY: &str = "AWS_SECRET_ACCESS_KEY";
 const ENV_AWS_SESSION_TOKEN: &str = "AWS_SESSION_TOKEN";
+// MinIO aliases (mirror Dart's `AppPackagePublisherMinio` configuration)
+const ENV_MINIO_ENDPOINT: &str = "MINIO_ENDPOINT";
+const ENV_MINIO_ACCESS_KEY: &str = "MINIO_ACCESS_KEY";
+const ENV_MINIO_SECRET_KEY: &str = "MINIO_SECRET_KEY";
 const DEFAULT_REGION: &str = "us-east-1";
 
 type HmacSha256 = Hmac<Sha256>;
@@ -169,37 +173,37 @@ impl S3PublishOptions {
     fn from_config(config: &PublishConfig) -> Result<Self, PublishError> {
         let endpoint = required_value(
             config,
-            &["endpoint", "s3-endpoint"],
-            &[ENV_S3_ENDPOINT],
+            &["endpoint", "s3-endpoint", "minio-endpoint"],
+            &[ENV_S3_ENDPOINT, ENV_MINIO_ENDPOINT],
             "S3 endpoint",
         )?;
         let region = optional_value(
             config,
-            &["region", "s3-region"],
+            &["region", "s3-region", "minio-region"],
             &[ENV_S3_REGION, ENV_AWS_REGION],
         )
         .unwrap_or_else(|| DEFAULT_REGION.to_string());
         let access_key = required_value(
             config,
-            &["access-key", "s3-access-key"],
-            &[ENV_S3_ACCESS_KEY, ENV_AWS_ACCESS_KEY_ID],
+            &["access-key", "s3-access-key", "minio-access-key"],
+            &[ENV_S3_ACCESS_KEY, ENV_AWS_ACCESS_KEY_ID, ENV_MINIO_ACCESS_KEY],
             "S3 access key",
         )?;
         let secret_key = required_value(
             config,
-            &["secret-key", "s3-secret-key"],
-            &[ENV_S3_SECRET_KEY, ENV_AWS_SECRET_ACCESS_KEY],
+            &["secret-key", "s3-secret-key", "minio-secret-key"],
+            &[ENV_S3_SECRET_KEY, ENV_AWS_SECRET_ACCESS_KEY, ENV_MINIO_SECRET_KEY],
             "S3 secret key",
         )?;
         let bucket = required_value(
             config,
-            &["bucket", "s3-bucket"],
+            &["bucket", "s3-bucket", "minio-bucket"],
             &[ENV_S3_BUCKET],
             "S3 bucket",
         )?;
         let key_prefix = optional_value(
             config,
-            &["savekey-prefix", "key-prefix", "s3-key-prefix"],
+            &["savekey-prefix", "key-prefix", "s3-key-prefix", "minio-savekey-prefix"],
             &[ENV_S3_KEY_PREFIX],
         );
         let public_base_url = optional_value(

--- a/crates/core/src/packager.rs
+++ b/crates/core/src/packager.rs
@@ -14,7 +14,12 @@ fn render_artifact_name(config: &PackageConfig) -> String {
     let build_number = config.app_version.split('+').nth(1).map(|s| s.to_string());
 
     let mut name = config.app_name.clone();
-    if let Some(flavor) = &config.flavor {
+    if let Some(channel) = &config.channel {
+        // Channel variant mirrors Dart's `_kArtifactNameWithChannel`:
+        // the channel replaces the flavor segment.
+        name.push('-');
+        name.push_str(channel);
+    } else if let Some(flavor) = &config.flavor {
         name.push('-');
         name.push_str(flavor);
     }
@@ -40,6 +45,90 @@ fn render_artifact_name(config: &PackageConfig) -> String {
     name
 }
 
+/// Renders a mustache-style artifact-name template, mirroring the template
+/// variables supported by Dart's `MakeConfig.outputArtifactPath`:
+/// `{{name}}`, `{{version}}`, `{{build_name}}`, `{{build_number}}`,
+/// `{{build_mode}}`, `{{platform}}`, `{{flavor}}`, `{{channel}}`, `{{ext}}`,
+/// plus boolean sections `{{#is_installer}}`, `{{#is_profile}}`,
+/// `{{#has_build_number}}` and value sections like `{{#flavor}}`/`{{#ext}}`.
+fn render_artifact_template(template: &str, config: &PackageConfig) -> String {
+    let build_name = config
+        .app_version
+        .split('+')
+        .next()
+        .unwrap_or(&config.app_version)
+        .to_string();
+    let build_number = config.app_version.split('+').nth(1).map(|s| s.to_string());
+    let ext = if config.package_format.is_empty() {
+        None
+    } else {
+        Some(config.package_format.clone())
+    };
+
+    let lookup = |key: &str| -> Option<String> {
+        match key {
+            "name" => Some(config.app_name.clone()),
+            "version" => Some(config.app_version.clone()),
+            "build_name" => Some(build_name.clone()),
+            "build_number" => build_number.clone(),
+            "build_mode" => Some(config.build_mode.clone()),
+            "platform" => Some(config.platform.as_str().to_string()),
+            "flavor" => config.flavor.clone(),
+            "channel" => config.channel.clone(),
+            "ext" => ext.clone(),
+            _ => None,
+        }
+    };
+    let truthy = |key: &str| -> bool {
+        match key {
+            "is_installer" => config.is_installer,
+            "is_profile" => config.build_mode == "profile",
+            "has_build_number" => build_number.is_some(),
+            other => lookup(other).is_some_and(|v| !v.is_empty()),
+        }
+    };
+
+    render_mustache(template, &lookup, &truthy)
+}
+
+/// Minimal mustache renderer supporting `{{var}}` interpolation and
+/// `{{#section}}...{{/section}}` conditional sections (nested allowed).
+fn render_mustache(
+    template: &str,
+    lookup: &dyn Fn(&str) -> Option<String>,
+    truthy: &dyn Fn(&str) -> bool,
+) -> String {
+    let mut output = String::new();
+    let mut rest = template;
+    while let Some(start) = rest.find("{{") {
+        output.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let Some(end) = after.find("}}") else {
+            output.push_str(&rest[start..]);
+            return output;
+        };
+        let tag = after[..end].trim();
+        rest = &after[end + 2..];
+        if let Some(section) = tag.strip_prefix('#') {
+            let close = format!("{{{{/{}}}}}", section);
+            if let Some(close_pos) = rest.find(&close) {
+                let inner = &rest[..close_pos];
+                rest = &rest[close_pos + close.len()..];
+                if truthy(section) {
+                    output.push_str(&render_mustache(inner, lookup, truthy));
+                }
+            }
+        } else if !tag.starts_with('/')
+            && !tag.starts_with('^')
+            && let Some(value) = lookup(tag)
+        {
+            output.push_str(&value);
+        }
+    }
+    output.push_str(rest);
+    output
+}
+
 #[derive(Debug, Clone)]
 pub struct PackageConfig {
     pub app_name: String,
@@ -60,7 +149,7 @@ pub struct PackageConfig {
 impl PackageConfig {
     pub fn output_file_name(&self) -> String {
         if let Some(template) = &self.artifact_name {
-            return template.clone();
+            return render_artifact_template(template, self);
         }
         render_artifact_name(self)
     }
@@ -134,4 +223,84 @@ pub trait AppPackager {
     }
 
     fn package(&self, config: &PackageConfig) -> Result<PackageResult, PackageError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_config() -> PackageConfig {
+        PackageConfig {
+            app_name: "hello_world".to_string(),
+            app_binary_name: "hello_world".to_string(),
+            app_version: "1.2.3+4".to_string(),
+            build_mode: "release".to_string(),
+            platform: Platform::Linux,
+            flavor: None,
+            channel: None,
+            artifact_name: None,
+            package_format: "deb".to_string(),
+            is_installer: true,
+            build_output_dir: PathBuf::new(),
+            build_output_files: vec![],
+            output_dir: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn default_artifact_name() {
+        assert_eq!(
+            base_config().output_file_name(),
+            "hello_world-1.2.3+4-linux-setup.deb"
+        );
+    }
+
+    #[test]
+    fn flavor_artifact_name() {
+        let mut config = base_config();
+        config.flavor = Some("dev".to_string());
+        assert_eq!(
+            config.output_file_name(),
+            "hello_world-dev-1.2.3+4-linux-setup.deb"
+        );
+    }
+
+    #[test]
+    fn channel_artifact_name_replaces_flavor_segment() {
+        let mut config = base_config();
+        config.flavor = Some("dev".to_string());
+        config.channel = Some("beta".to_string());
+        assert_eq!(
+            config.output_file_name(),
+            "hello_world-beta-1.2.3+4-linux-setup.deb"
+        );
+    }
+
+    #[test]
+    fn artifact_name_template_variables() {
+        let mut config = base_config();
+        config.artifact_name = Some("{{name}}_{{build_name}}_amd64.{{ext}}".to_string());
+        assert_eq!(config.output_file_name(), "hello_world_1.2.3_amd64.deb");
+    }
+
+    #[test]
+    fn artifact_name_template_sections() {
+        let mut config = base_config();
+        config.artifact_name = Some(
+            "{{name}}{{#flavor}}-{{flavor}}{{/flavor}}-{{build_name}}{{#has_build_number}}+{{build_number}}{{/has_build_number}}{{#is_profile}}-{{build_mode}}{{/is_profile}}-{{platform}}{{#is_installer}}-setup{{/is_installer}}{{#ext}}.{{ext}}{{/ext}}"
+                .to_string(),
+        );
+        // Matches Dart's default template output exactly
+        assert_eq!(
+            config.output_file_name(),
+            "hello_world-1.2.3+4-linux-setup.deb"
+        );
+    }
+
+    #[test]
+    fn artifact_name_literal_passthrough() {
+        let mut config = base_config();
+        config.artifact_name = Some("MyApp-Installer.deb".to_string());
+        assert_eq!(config.output_file_name(), "MyApp-Installer.deb");
+    }
 }

--- a/packages/flutter_app_packager/CHANGELOG.md
+++ b/packages/flutter_app_packager/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.6.11
 
+* feat(appimage): add optional `startup_wm_class` / StartupWMClass support (mirrors MakeDebConfig #290)
 * feat(rpm): add support for custom `package_name` to rename package artifacts (#355)
 * fix(rpm): remove system modification command from `%install` section
 * fix(rpm): enable post-install scripts and fix post-uninstall logic

--- a/packages/flutter_app_packager/lib/src/makers/appimage/make_appimage_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/appimage/make_appimage_config.dart
@@ -39,6 +39,7 @@ class MakeAppImageConfig extends MakeConfig {
     this.actions = const [],
     this.include = const [],
     this.startupNotify = true,
+    this.startupWMClass,
     this.genericName = 'A Flutter Application',
     this.supportedMimeType,
     this.metainfo,
@@ -52,6 +53,7 @@ class MakeAppImageConfig extends MakeConfig {
       keywords: (map['keywords'] as List<dynamic>? ?? []).cast<String>(),
       categories: (map['categories'] as List<dynamic>? ?? []).cast<String>(),
       startupNotify: map['startup_notify'] as bool? ?? false,
+      startupWMClass: map['startup_wm_class'] as String?,
       genericName: map['generic_name'] as String? ?? 'A Flutter Application',
       actions: (map['actions'] as List? ?? [])
           .map(
@@ -72,6 +74,7 @@ class MakeAppImageConfig extends MakeConfig {
   final List<String> categories;
   final List<AppImageAction> actions;
   final bool startupNotify;
+  final String? startupWMClass;
   final String genericName;
   final String displayName;
   final List<String> include;
@@ -85,6 +88,8 @@ class MakeAppImageConfig extends MakeConfig {
       'Icon': appName,
       'Type': 'Application',
       'StartupNotify': startupNotify ? 'true' : 'false',
+      if (startupWMClass != null && startupWMClass!.isNotEmpty)
+        'StartupWMClass': startupWMClass,
       if (supportedMimeType != null && supportedMimeType!.isNotEmpty)
         'MimeType': '${supportedMimeType!.join(';')};',
       if (categories.isNotEmpty) 'Categories': categories.join(';'),


### PR DESCRIPTION
## Summary
- Add optional `startup_wm_class` / `startupWMClass` to `MakeAppImageConfig`, emitting `StartupWMClass` in the generated `.desktop` file when non-null/non-empty (same pattern as `MakeDebConfig` #290).
- Keep the Rust AppImage packager schema/desktop renderer in sync, with unit coverage for emit/omit behavior.
- Document the field in EN/ZH AppImage maker docs and note it in `flutter_app_packager` CHANGELOG.

This lets GNOME/KDE correctly group AppImage windows that use a GTK `application-id` different from the binary name.

## Test plan
- [x] `dart analyze` on `packages/flutter_app_packager/lib/src/makers/appimage/`
- [x] Confirm packaging with `startup_wm_class` set produces a `.desktop` containing `StartupWMClass=...`
- [x] Confirm omitting / empty `startup_wm_class` does not emit the key
- [x] Spot-check GNOME/KDE taskbar/icon grouping against GTK application-id
